### PR TITLE
Improve schema defaults

### DIFF
--- a/dev/defaults/app.vue
+++ b/dev/defaults/app.vue
@@ -1,0 +1,36 @@
+<template lang="html">
+	<div>
+		<vue-form-generator :schema="schema" :model="model" :options="formOptions"></vue-form-generator>
+	</div>
+</template>
+
+<script>
+import Vue from "vue";
+import Multiselect from "vue-multiselect"
+Vue.component("multiselect", Multiselect);
+
+export default {
+	data () {
+		return {
+			model: {
+				skills: ["Javascript", "VueJS"],
+				first_name: "Brian Blessed"
+			},
+
+			schema: {
+				fields: [
+					{
+						label: "First Name"
+					}
+				]
+			},
+
+			formOptions: {}
+		}
+	},
+
+	created() {
+		window.app = this;
+	}
+}
+</script>

--- a/dev/defaults/index.html
+++ b/dev/defaults/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>vue-form-generator simple defaults demo</title>
+  </head>
+  <body>
+    <div class="container-fluid"></div>
+    <div id="app"></div>
+  	<script src="/defaults.js"></script>
+  </body>
+</html>

--- a/dev/defaults/main.js
+++ b/dev/defaults/main.js
@@ -1,0 +1,9 @@
+import Vue from "vue";
+import VueFormGenerator from "../../src";
+Vue.use(VueFormGenerator);
+
+import App from "./app.vue";
+
+new Vue({
+  ...App
+}).$mount("#app");

--- a/src/fields/abstractField.js
+++ b/src/fields/abstractField.js
@@ -1,5 +1,6 @@
 import { get as objGet, each, isFunction, isString, isArray } from "lodash";
 import validators from "../utils/validators";
+import slugify from "../utils/slugify";
 
 function convertValidator(validator) {
 	if (isString(validator)) {
@@ -170,21 +171,7 @@ export default {
 				return schema.id;
 			} else {
 				// Return the slugified version of either:
-				return (schema.inputName || schema.label || schema.model)
-				// NB: This is a very simple, conservative, slugify function,
-				// avoiding extra dependencies.
-				.toString()
-				.trim()
-				.toLowerCase()
-				// Spaces & underscores to dashes
-				.replace(/ |_/g, "-")
-				// Multiple dashes to one
-				.replace(/-{2,}/g, "-")
-				// Remove leading & trailing dashes
-				.replace(/^-+|-+$/g, "")
-				// Remove anything that isn't a (English/ASCII) letter, number or dash.
-				.replace(/([^a-zA-Z0-9-]+)/g, "")
-				;
+				return slugify(schema.inputName || schema.label || schema.model);
 			}
 		}
 

--- a/src/formGenerator.vue
+++ b/src/formGenerator.vue
@@ -21,6 +21,7 @@ div
 	// import Vue from "vue";
 	import {each, isFunction, isNil, isArray, isString} from "lodash";
 	import getFieldID from "./fields/abstractField";
+	import slugify from "./utils/slugify";
 
 	// Load all fields from '../fields' folder
 	let fieldComponents = {};
@@ -119,6 +120,25 @@ div
 							this.clearValidationErrors();
 					});
 				}
+			}
+		},
+
+		beforeMount() {
+			// Apply default schema properties
+			for (let field of this.schema.fields) {
+				if (!("type" in field)) {
+					// No type defined, default to input
+					field.type = "input";
+					if (!("inputType" in field)) {
+						// No inputType defined, default to text
+						field.inputType = "text";
+					}
+				}
+				if (!("model" in field)) {
+					// No model defined, default to slugified label
+					field.model = slugify(field.label, "_");
+				}
+				console.log(field);
 			}
 		},
 

--- a/src/utils/slugify.js
+++ b/src/utils/slugify.js
@@ -1,0 +1,23 @@
+export default function slugify(str, slug) {
+	// NB: This is a very simple, conservative, slugify function,
+	// avoiding extra dependencies.
+
+	// Default the slug char to a dash
+	if (typeof slug === "undefined") {
+		slug = "-";
+	}
+
+	return str
+		.toString()
+		.trim()
+		.toLowerCase()
+		// Spaces to slugs
+		.replace(/\s+/g, slug)
+		// Multiple slugs to one
+		.replace(new RegExp(`${slug}{2,}`), slug)
+		// Remove leading & trailing slugs
+		.replace(new RegExp(`^${slug}+|${slug}+$`), "")
+		// Remove anything that isn't a (English/ASCII) letter, number or slug
+		.replace(new RegExp(`[^a-zA-Z0-9${slug}]`), "")
+		;
+}

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -17,23 +17,24 @@ var loaders = [
 		test: /\.json$/,
 		loader: 'json'
 	},
-	{ 
-		test: /\.(woff2?|svg)$/, 
-		loader: "url" 
-		//loader: "url?limit=10000" 
+	{
+		test: /\.(woff2?|svg)$/,
+		loader: "url"
+		//loader: "url?limit=10000"
 	},
-	{ 
-		test: /\.(ttf|eot)$/, 
-		loader: "url" 
+	{
+		test: /\.(ttf|eot)$/,
+		loader: "url"
 	}
 ];
 
 module.exports = {
 	devtool: "source-map",
-	
+
 	entry: {
 		full: path.resolve("dev", "full", "main.js"),
 		mselect: path.resolve("dev", "multiselect", "main.js"),
+		defaults: path.resolve("dev", "defaults", "main.js"),
 		checklist: path.resolve("dev", "checklist", "main.js")
 	},
 


### PR DESCRIPTION
Supply default values for `schema.type`, `schema.inputType` & `schema.model`.

This is a test, to see what you think, but the idea is to make schema's smaller by supplying defaults for some fields if they're not supplied. This would make this:

```js
schema: { 
  fields: [
    {
      type: "input",
      inputType: "text",
      label: "First Name",
      model: "first_name",
    },
    {
      type: "input",
      inputType: "text",
      label: "Last Name",
      model: "last_name",
    }
  ]
}
```

equivalent to this:

```js
schema: { 
  fields: [
    { label: "First Name" },
    { label: "Last Name" }
  ]
}
```

... which for large forms with lots of text boxes, ends up being a huge saving.

This works by adding a `beforeMount()` to `formGenerator.vue` which sets defaults in the `schema`, if required. I also added a `dev/defaults/index.html` test for this.

This works, as far as it goes - but it seems to break about 50% of the tests, for reasons I haven't looked into.

I'm not sure about this particular implementation, but I _do_ think that making the schema declarations smaller for the common case would be a good thing.