### PR TITLE
fix bower.json validation

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "dist/vfg.js",
     "dist/vfg.css",
     "dist/vfg-core.js",
-    "dist/vfg-core.css",
+    "dist/vfg-core.css"
   ],
   "moduleType": [
     "amd"


### PR DESCRIPTION
Installing 2.1.1 using bower 1.8.2 results in an EMALFORMED error.

Additional error details:
Unexpected token ] in JSON at position 324

The error is caused by the comma at the end of line https://github.com/vue-generators/vue-form-generator/blob/master/bower.json#L13, introduced in b8d5820d1eb88e8b12764fca2837e0349f01ce18.