### PR TITLE
fixes #345 - declare debouncedValidateFunc

### DIFF
--- a/src/fields/abstractField.js
+++ b/src/fields/abstractField.js
@@ -1,4 +1,4 @@
-import { uniqueId, get as objGet, each, isFunction, isString, isArray, debounce } from "lodash";
+import { get as objGet, each, isFunction, isString, isArray, debounce } from "lodash";
 import validators from "../utils/validators";
 import { slugifyFormID } from "../utils/schema";
 

--- a/src/fields/abstractField.js
+++ b/src/fields/abstractField.js
@@ -79,7 +79,6 @@ export default {
 
 	methods: {
 		validate(calledParent) {
-			console.log('validating', performance.now());
 			this.clearValidationErrors();
 
 			if (this.schema.validator && this.schema.readonly !== true && this.disabled !== true) {
@@ -131,10 +130,8 @@ export default {
 		},
 		debouncedValidate() {
 			if(!isFunction(this.debouncedValidateFunc)) {
-				console.log('debouncedValidate', 'config', objGet(this, '$parent.optionsvalidateDebounceTime', 500));
-				this.debouncedValidateFunc = debounce(this.validate.bind(this), objGet(this, '$parent.options.validateDebounceTime', 500));
+				this.debouncedValidateFunc = debounce(this.validate.bind(this), objGet(this, "$parent.options.validateDebounceTime", 500));
 			}
-			console.log('debouncedValidate', performance.now());
 			this.debouncedValidateFunc();
 		},
 		clearValidationErrors() {

--- a/src/fields/abstractField.js
+++ b/src/fields/abstractField.js
@@ -1,4 +1,4 @@
-import { get as objGet, each, isFunction, isString, isArray, debounce } from "lodash";
+import { uniqueId, get as objGet, each, isFunction, isString, isArray, debounce } from "lodash";
 import validators from "../utils/validators";
 import { slugifyFormID } from "../utils/schema";
 
@@ -24,7 +24,8 @@ export default {
 
 	data() {
 		return {
-			errors: []
+			errors: [],
+			debouncedValidateFunc: null
 		};
 	},
 
@@ -66,9 +67,6 @@ export default {
 
 					if (this.$parent.options && this.$parent.options.validateAfterChanged === true) {
 						if (this.$parent.options.validateDebounceTime > 0) {
-							if (!this.debouncedValidate)
-								this.debouncedValidate = debounce(this.validate.bind(this), this.$parent.options.validateDebounceTime);
-
 							this.debouncedValidate();
 						} else {
 							this.validate();
@@ -81,6 +79,7 @@ export default {
 
 	methods: {
 		validate(calledParent) {
+			console.log('validating', performance.now());
 			this.clearValidationErrors();
 
 			if (this.schema.validator && this.schema.readonly !== true && this.disabled !== true) {
@@ -130,7 +129,14 @@ export default {
 
 			return this.errors;
 		},
-
+		debouncedValidate() {
+			if(!isFunction(this.debouncedValidateFunc)) {
+				console.log('debouncedValidate', 'config', objGet(this, '$parent.optionsvalidateDebounceTime', 500));
+				this.debouncedValidateFunc = debounce(this.validate.bind(this), objGet(this, '$parent.options.validateDebounceTime', 500));
+			}
+			console.log('debouncedValidate', performance.now());
+			this.debouncedValidateFunc();
+		},
 		clearValidationErrors() {
 			this.errors.splice(0);
 		},


### PR DESCRIPTION
declare debouncedValidateFunc and set it when debouncedValidate() is called... vue 2.2.0 prevents you from attaching methods/properties to components that have not been declared