### PR TITLE
Fix #422 "fieldUpload event throws ReferenceError in Firefox"

### DIFF
--- a/src/fields/core/fieldUpload.vue
+++ b/src/fields/core/fieldUpload.vue
@@ -20,10 +20,10 @@ import { isFunction } from "lodash";
 export default {
 	mixins: [abstractField],
 	methods: {
-		onChange(event){
+		onChange($event){
 			if(isFunction(this.schema.onChanged)){
 				// Schema has defined onChange method.
-				this.schema.onChanged.call(this, this.model, this.schema, event, this);
+				this.schema.onChanged.call(this, this.model, this.schema, $event, this);
 			}
 		}
 	}

--- a/src/fields/core/fieldUpload.vue
+++ b/src/fields/core/fieldUpload.vue
@@ -20,7 +20,7 @@ import { isFunction } from "lodash";
 export default {
 	mixins: [abstractField],
 	methods: {
-		onChange(){
+		onChange(event){
 			if(isFunction(this.schema.onChanged)){
 				// Schema has defined onChange method.
 				this.schema.onChanged.call(this, this.model, this.schema, event, this);


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
Firefox throws reference error when using fieldUpload and onChange callback

* **What is the new behavior (if this is a feature change)?**
Firefox doesnt throw reference error and user get the event object in onChange callback function

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
