### PR TITLE
closes #434, #408 - added $event to onValidationError

### DIFF
--- a/src/fields/core/fieldSubmit.vue
+++ b/src/fields/core/fieldSubmit.vue
@@ -12,10 +12,13 @@
 		methods: {
 			onClick($event) {
 				if (this.schema.validateBeforeSubmit === true) {
+					// prevent a <form /> from having it's submit event triggered
+					// when we have to validate data first
+					$event.preventDefault();
 					let errors = this.$parent.validate();
 					let handleErrors = (errors) => {
 						if(!isEmpty(errors) && isFunction(this.schema.onValidationError)) {
-							this.schema.onValidationError(this.model, this.schema, errors);
+							this.schema.onValidationError(this.model, this.schema, errors, $event);
 						} else if (isFunction(this.schema.onSubmit)) {
 							this.schema.onSubmit(this.model, this.schema, $event);
 						}
@@ -27,6 +30,8 @@
 						handleErrors(errors);
 					}
 				} else if (isFunction(this.schema.onSubmit)) {
+					// if we aren't validating, just pass the onSubmit handler the $event
+					// so it can be handled there
 					this.schema.onSubmit(this.model, this.schema, $event);
 				}
 			}


### PR DESCRIPTION
added $event to onValidationError and call preventDefault when onValidateBeforeSubmit is true

We can't prevent the submit after waiting for async validation, so we just prevent it before calling any validation and let the user
manually submit the form in the `onSubmit` handler, if it validates.

* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix

- **What is the current behavior?** (You can also link to an open issue here)
`<form />` are submitted when using `submit` field with validateBeforeSubmit.

* **What is the new behavior (if this is a feature change)?**
`validateBeforeSubmit: true` calls `$event.preventDefault()` and prevents the form submission 

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
This PR should introduce "expected behavior", so users should not need to do anything.

* **Other information**:
