### PR TITLE
resolves #429

### DIFF
--- a/src/formGenerator.vue
+++ b/src/formGenerator.vue
@@ -168,28 +168,17 @@ div.vue-form-generator(v-if='schema != null')
 			getFieldRowClasses(field) {
 				const hasErrors = this.fieldErrors(field).length > 0;
 				let baseClasses = {
-					error: hasErrors,
+					[_.get(this.options, 'validationErrorClass', 'error')]: hasErrors,
+					[_.get(this.options, 'validationSuccessClass', 'valid')]: !hasErrors,
 					disabled: this.fieldDisabled(field),
 					readonly: this.fieldReadonly(field),
 					featured: this.fieldFeatured(field),
 					required: this.fieldRequired(field)
 				};
 
-				let {validationErrorClass, validationSuccessClass} = this.options;
-				if (validationErrorClass && validationSuccessClass) {
-					if (hasErrors) {
-						baseClasses[validationErrorClass] = true;
-						baseClasses.error = false;
-					}
-					else {
-						baseClasses[validationSuccessClass] = true;
-					}
-				}
-
 				if (isArray(field.styleClasses)) {
 					forEach(field.styleClasses, (c) => baseClasses[c] = true);
-				}
-				else if (isString(field.styleClasses)) {
+				} else if (isString(field.styleClasses)) {
 					baseClasses[field.styleClasses] = true;
 				}
 

--- a/src/formGenerator.vue
+++ b/src/formGenerator.vue
@@ -168,8 +168,8 @@ div.vue-form-generator(v-if='schema != null')
 			getFieldRowClasses(field) {
 				const hasErrors = this.fieldErrors(field).length > 0;
 				let baseClasses = {
-					[objGet(this.options, 'validationErrorClass', 'error')]: hasErrors,
-					[objGet(this.options, 'validationSuccessClass', 'valid')]: !hasErrors,
+					[objGet(this.options, "validationErrorClass", "error")]: hasErrors,
+					[objGet(this.options, "validationSuccessClass", "valid")]: !hasErrors,
 					disabled: this.fieldDisabled(field),
 					readonly: this.fieldReadonly(field),
 					featured: this.fieldFeatured(field),

--- a/src/formGenerator.vue
+++ b/src/formGenerator.vue
@@ -168,8 +168,8 @@ div.vue-form-generator(v-if='schema != null')
 			getFieldRowClasses(field) {
 				const hasErrors = this.fieldErrors(field).length > 0;
 				let baseClasses = {
-					[_.get(this.options, 'validationErrorClass', 'error')]: hasErrors,
-					[_.get(this.options, 'validationSuccessClass', 'valid')]: !hasErrors,
+					[objGet(this.options, 'validationErrorClass', 'error')]: hasErrors,
+					[objGet(this.options, 'validationSuccessClass', 'valid')]: !hasErrors,
 					disabled: this.fieldDisabled(field),
 					readonly: this.fieldReadonly(field),
 					featured: this.fieldFeatured(field),


### PR DESCRIPTION
modified how validationErrorClass and validationSuccessClass are handled

* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

- **What is the current behavior?** (You can also link to an open issue here)
validationErrorClass and validationSuccessClass both needed to be defined for one of them to work.

* **What is the new behavior (if this is a feature change)?**
you can define either validationErrorClass or validationSuccessClass and they will work.  validationSuccessClass now has a default value of 'valid'

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No, it should not - unless someone has CSS classes for 'valid' that may cause visual issues

* **Other information**:
resolves #429 