### PR TITLE
#425 - made DEBOUNCE_FORMAT_MS configurable in the schema

### DIFF
--- a/src/fields/core/fieldInput.vue
+++ b/src/fields/core/fieldInput.vue
@@ -113,7 +113,7 @@ export default {
 			case "range":
 				this.debouncedFormatFunc = debounce((newValue, oldValue) => {
 					this.formatNumberToModel(newValue, oldValue);
-				}, parseInt(objGet(this.schema, 'debounceFormatTimeout', 1000)), {
+				}, parseInt(objGet(this.schema, "debounceFormatTimeout", 1000)), {
 					trailing: true,
 					leading: false
 				});
@@ -124,7 +124,7 @@ export default {
 				// wait 1s before calling 'formatDatetimeToModel' to allow user to input data
 				this.debouncedFormatFunc = debounce((newValue, oldValue) => {
 					this.formatDatetimeToModel(newValue, oldValue);
-				}, parseInt(objGet(this.schema, 'debounceFormatTimeout', 1000)), {
+				}, parseInt(objGet(this.schema, "debounceFormatTimeout", 1000)), {
 					trailing: true,
 					leading: false
 				});

--- a/src/fields/core/fieldInput.vue
+++ b/src/fields/core/fieldInput.vue
@@ -41,7 +41,7 @@
 
 <script>
 import abstractField from "../abstractField";
-import { debounce, isFunction, isNumber } from "lodash";
+import { debounce, get as objGet, isFunction, isNumber } from "lodash";
 import fecha from "fecha";
 
 const DATETIME_FORMATS = {
@@ -49,8 +49,6 @@ const DATETIME_FORMATS = {
 	"datetime": "YYYY-MM-DD HH:mm:ss",
 	"datetime-local": "YYYY-MM-DDTHH:mm:ss",
 };
-
-const DEBOUNCE_FORMAT_MS = 1000;
 
 export default {
 	mixins: [abstractField],
@@ -115,8 +113,7 @@ export default {
 			case "range":
 				this.debouncedFormatFunc = debounce((newValue, oldValue) => {
 					this.formatNumberToModel(newValue, oldValue);
-				}
-				, DEBOUNCE_FORMAT_MS, {
+				}, parseInt(objGet(this.schema, 'debounceFormatTimeout', 1000)), {
 					trailing: true,
 					leading: false
 				});
@@ -127,8 +124,7 @@ export default {
 				// wait 1s before calling 'formatDatetimeToModel' to allow user to input data
 				this.debouncedFormatFunc = debounce((newValue, oldValue) => {
 					this.formatDatetimeToModel(newValue, oldValue);
-				}
-				, DEBOUNCE_FORMAT_MS, {
+				}, parseInt(objGet(this.schema, 'debounceFormatTimeout', 1000)), {
 					trailing: true,
 					leading: false
 				});


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature/bug fix?

- **What is the current behavior?** (You can also link to an open issue here)
DEBOUNCE_FORMAT_MS is hard-coded to 1000ms

* **What is the new behavior (if this is a feature change)?**
DEBOUNCE_FORMAT_MS was replaced with `debounceFormatTimeout` schema property to allow it to be configurable

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
you can now set `debounceFormatTimeout` to adjust how long the field will "wait" before attempting to format the value ... defaults to 1s, and allows you to accommodate "slower data entry".