### PR TITLE
Fix bug in IE11 and Edge

### DIFF
--- a/src/fields/core/fieldInput.vue
+++ b/src/fields/core/fieldInput.vue
@@ -94,8 +94,8 @@ export default {
 			switch (this.schema.inputType.toLowerCase()) {
 				case "number":
 				case "range":
-					if (isNumber($event.target.valueAsNumber)) {
-						value = $event.target.valueAsNumber;
+					if (isNumber(parseFloat($event.target.value))) {
+						value = parseFloat($event.target.value);
 					}
 					break;
 			}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix a bug with `valueAsNumber` and IE11 and Edge
- **What is the current beha**vior?** (You can also link to an open issue here)
IE11 and Edge return `NaN` even with number
* **What is the new behavior (if this is a feature change)?**
Should return the good value
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
https://github.com/vue-generators/vue-form-generator/issues/361
https://github.com/vue-generators/vue-form-generator/pull/363