### PR TITLE
Improve field loading method

### DIFF
--- a/dev/projects/basic/main.js
+++ b/dev/projects/basic/main.js
@@ -1,7 +1,10 @@
 import Vue from "vue";
 
 import VueFormGenerator from "@";
-Vue.use(VueFormGenerator);
+import { fieldCheckbox, fieldInput, fieldSubmit } from "@/utils/fieldsLoader.js";
+Vue.use(VueFormGenerator, {
+	fields: [fieldCheckbox, fieldInput, fieldSubmit]
+});
 
 import VueHighlightJS from "vue-highlightjs";
 Vue.use(VueHighlightJS);

--- a/dev/projects/checklist/app.vue
+++ b/dev/projects/checklist/app.vue
@@ -16,7 +16,8 @@
 
 <script>
 /* eslint no-console: 0 */
-import { validators } from "../../../src";
+import VueFormGenerator from "../../../src/index.js";
+const validators = VueFormGenerator.validators;
 import mixinUtils from "../../mixins/utils.js";
 
 export default {

--- a/dev/projects/checklist/main.js
+++ b/dev/projects/checklist/main.js
@@ -1,7 +1,10 @@
 import Vue from "vue";
 
 import VueFormGenerator from "@";
-Vue.use(VueFormGenerator);
+import { fieldChecklist } from "@/utils/fieldsLoader.js";
+Vue.use(VueFormGenerator, {
+	fields: [fieldChecklist]
+});
 
 import VueHighlightJS from "vue-highlightjs";
 Vue.use(VueHighlightJS);

--- a/dev/projects/custom/main.js
+++ b/dev/projects/custom/main.js
@@ -1,7 +1,10 @@
 import Vue from "vue";
 
 import VueFormGenerator from "@";
-Vue.use(VueFormGenerator);
+import { fieldInput } from "@/utils/fieldsLoader.js";
+Vue.use(VueFormGenerator, {
+	fields: [fieldInput]
+});
 
 import VueHighlightJS from "vue-highlightjs";
 Vue.use(VueHighlightJS);

--- a/dev/projects/full/app.vue
+++ b/dev/projects/full/app.vue
@@ -36,7 +36,7 @@
 <script>
 /* eslint no-console: 0 */
 import Vue from "vue";
-import VueFormGenerator from "../../../src";
+import VueFormGenerator from "@";
 import DataTable from "./dataTable.vue";
 import Fakerator from "fakerator";
 
@@ -47,13 +47,7 @@ import mixinUtils from "../../mixins/utils.js";
 import Multiselect from "vue-multiselect";
 Vue.component("multiselect", Multiselect);
 
-// Test custom field
-import FieldAwesome from "./fieldAwesome.vue";
-Vue.component("fieldAwesome", FieldAwesome);
-
 import { each, cloneDeep, merge } from "lodash";
-
-Vue.use(VueFormGenerator);
 
 let fakerator = new Fakerator();
 

--- a/dev/projects/full/fieldAwesome.vue
+++ b/dev/projects/full/fieldAwesome.vue
@@ -3,9 +3,10 @@
 </template>
 
 <script>
-import VueFormGenerator from "../../../src";
+import VueFormGenerator from "@";
 
 export default {
+	name: "field-awesome",
 	mixins: [VueFormGenerator.abstractField]
 };
 </script>

--- a/dev/projects/full/main.js
+++ b/dev/projects/full/main.js
@@ -1,7 +1,60 @@
 import Vue from "vue";
 
 import VueFormGenerator from "@";
-Vue.use(VueFormGenerator);
+import {
+	fieldCheckbox,
+	fieldChecklist,
+	fieldInput,
+	fieldLabel,
+	fieldRadios,
+	fieldSelect,
+	fieldSubmit,
+	fieldTextArea,
+	fieldUpload,
+	fieldCleave,
+	fieldDateTimePicker,
+	fieldGoogleAddress,
+	fieldImage,
+	fieldMasked,
+	fieldNoUiSlider,
+	fieldPikaday,
+	fieldRangeSlider,
+	fieldSelectEx,
+	fieldSpectrum,
+	fieldStaticMap,
+	fieldSwitch,
+	fieldVueMultiSelect
+} from "@/utils/fieldsLoader.js";
+// Test custom field
+import fieldAwesome from "./fieldAwesome.vue";
+
+Vue.use(VueFormGenerator, {
+	fields: [
+		fieldAwesome,
+		fieldCheckbox,
+		fieldChecklist,
+		fieldInput,
+		fieldLabel,
+		fieldRadios,
+		fieldSelect,
+		fieldSubmit,
+		fieldTextArea,
+		fieldUpload,
+		fieldCleave,
+		fieldDateTimePicker,
+		fieldGoogleAddress,
+		fieldImage,
+		fieldMasked,
+		fieldNoUiSlider,
+		fieldPikaday,
+		fieldRangeSlider,
+		fieldSelectEx,
+		fieldSpectrum,
+		fieldStaticMap,
+		fieldSwitch,
+		fieldVueMultiSelect
+	]
+});
 
 import VueHighlightJS from "vue-highlightjs";
 Vue.use(VueHighlightJS);

--- a/dev/projects/full/schema.js
+++ b/dev/projects/full/schema.js
@@ -1,7 +1,8 @@
 /* eslint no-console: 0 */
 import fecha from "fecha";
 
-import { validators } from "../../../src";
+import VueFormGenerator from "@";
+const validators = VueFormGenerator.validators;
 
 let customAsyncValidator = function(value) {
 	return new Promise((resolve, reject) => {

--- a/dev/projects/grouping/main.js
+++ b/dev/projects/grouping/main.js
@@ -1,7 +1,10 @@
 import Vue from "vue";
 
 import VueFormGenerator from "@";
-Vue.use(VueFormGenerator);
+import { fieldInput } from "@/utils/fieldsLoader.js";
+Vue.use(VueFormGenerator, {
+	fields: [fieldInput]
+});
 
 import VueHighlightJS from "vue-highlightjs";
 Vue.use(VueHighlightJS);

--- a/dev/projects/multi/main.js
+++ b/dev/projects/multi/main.js
@@ -1,7 +1,10 @@
 import Vue from "vue";
 
 import VueFormGenerator from "@";
-Vue.use(VueFormGenerator);
+import { fieldCheckbox, fieldInput, fieldSubmit } from "@/utils/fieldsLoader.js";
+Vue.use(VueFormGenerator, {
+	fields: [fieldCheckbox, fieldInput, fieldSubmit]
+});
 
 import VueHighlightJS from "vue-highlightjs";
 Vue.use(VueHighlightJS);

--- a/dev/projects/multiselect/main.js
+++ b/dev/projects/multiselect/main.js
@@ -1,7 +1,10 @@
 import Vue from "vue";
 
 import VueFormGenerator from "@";
-Vue.use(VueFormGenerator);
+import { fieldVueMultiSelect } from "@/utils/fieldsLoader.js";
+Vue.use(VueFormGenerator, {
+	fields: [fieldVueMultiSelect]
+});
 
 import VueHighlightJS from "vue-highlightjs";
 Vue.use(VueHighlightJS);

--- a/dev/projects/picker/main.js
+++ b/dev/projects/picker/main.js
@@ -1,7 +1,10 @@
 import Vue from "vue";
 
 import VueFormGenerator from "@";
-Vue.use(VueFormGenerator);
+import { fieldDateTimePicker } from "@/utils/fieldsLoader.js";
+Vue.use(VueFormGenerator, {
+	fields: [fieldDateTimePicker]
+});
 
 import VueHighlightJS from "vue-highlightjs";
 Vue.use(VueHighlightJS);

--- a/src/fields/core/fieldCheckbox.vue
+++ b/src/fields/core/fieldCheckbox.vue
@@ -6,6 +6,7 @@
 import abstractField from "../abstractField";
 
 export default {
+	name: "field-checkbox",
 	mixins: [abstractField]
 };
 </script>

--- a/src/fields/core/fieldChecklist.vue
+++ b/src/fields/core/fieldChecklist.vue
@@ -24,6 +24,7 @@ import abstractField from "../abstractField";
 import { slugify } from "../../utils/schema";
 
 export default {
+	name: "field-checklist",
 	mixins: [abstractField],
 
 	data() {

--- a/src/fields/core/fieldInput.vue
+++ b/src/fields/core/fieldInput.vue
@@ -52,6 +52,7 @@ const DATETIME_FORMATS = {
 };
 
 export default {
+	name: "field-input",
 	mixins: [abstractField],
 	computed: {
 		inputType() {

--- a/src/fields/core/fieldLabel.vue
+++ b/src/fields/core/fieldLabel.vue
@@ -6,6 +6,7 @@
 import abstractField from "../abstractField";
 
 export default {
+	name: "field-label",
 	mixins: [abstractField]
 };
 </script>

--- a/src/fields/core/fieldRadios.vue
+++ b/src/fields/core/fieldRadios.vue
@@ -11,6 +11,7 @@ import { isObject } from "lodash";
 import abstractField from "../abstractField";
 
 export default {
+	name: "field-radios",
 	mixins: [abstractField],
 
 	computed: {

--- a/src/fields/core/fieldSelect.vue
+++ b/src/fields/core/fieldSelect.vue
@@ -14,6 +14,7 @@ import { isObject, isNil, find } from "lodash";
 import abstractField from "../abstractField";
 
 export default {
+	name: "field-select",
 	mixins: [abstractField],
 
 	computed: {

--- a/src/fields/core/fieldSubmit.vue
+++ b/src/fields/core/fieldSubmit.vue
@@ -7,6 +7,7 @@ import abstractField from "../abstractField";
 import { isFunction, isEmpty } from "lodash";
 
 export default {
+	name: "field-submit",
 	mixins: [abstractField],
 
 	methods: {

--- a/src/fields/core/fieldTextArea.vue
+++ b/src/fields/core/fieldTextArea.vue
@@ -17,6 +17,7 @@
 import abstractField from "../abstractField";
 
 export default {
+	name: "field-textArea",
 	mixins: [abstractField]
 };
 </script>

--- a/src/fields/core/fieldUpload.vue
+++ b/src/fields/core/fieldUpload.vue
@@ -19,6 +19,7 @@ import abstractField from "../abstractField";
 import { isFunction } from "lodash";
 
 export default {
+	name: "field-upload",
 	mixins: [abstractField],
 	methods: {
 		onChange($event) {

--- a/src/fields/optional/fieldCleave.vue
+++ b/src/fields/optional/fieldCleave.vue
@@ -7,6 +7,7 @@ import abstractField from "../abstractField";
 import { defaults } from "lodash";
 
 export default {
+	name: "field-cleave",
 	mixins: [abstractField],
 
 	data() {

--- a/src/fields/optional/fieldDateTimePicker.vue
+++ b/src/fields/optional/fieldDateTimePicker.vue
@@ -12,6 +12,7 @@ import { defaults } from "lodash";
 import dateFieldHelper from "../../utils/dateFieldHelper";
 
 export default {
+	name: "field-dateTimePicker",
 	mixins: [abstractField],
 
 	methods: {

--- a/src/fields/optional/fieldGoogleAddress.vue
+++ b/src/fields/optional/fieldGoogleAddress.vue
@@ -13,6 +13,7 @@ import { isFunction } from "lodash";
 
 /* global google */
 export default {
+	name: "field-googleAddress",
 	mixins: [abstractField],
 
 	data() {

--- a/src/fields/optional/fieldImage.vue
+++ b/src/fields/optional/fieldImage.vue
@@ -10,6 +10,7 @@
 import abstractField from "../abstractField";
 
 export default {
+	name: "field-image",
 	mixins: [abstractField],
 
 	computed: {

--- a/src/fields/optional/fieldMasked.vue
+++ b/src/fields/optional/fieldMasked.vue
@@ -7,6 +7,7 @@
 import abstractField from "../abstractField";
 
 export default {
+	name: "field-masked",
 	mixins: [abstractField],
 
 	mounted() {

--- a/src/fields/optional/fieldNoUiSlider.vue
+++ b/src/fields/optional/fieldNoUiSlider.vue
@@ -7,6 +7,7 @@ import abstractField from "../abstractField";
 import { isArray, defaults } from "lodash";
 
 export default {
+	name: "field-noUiSlider",
 	mixins: [abstractField],
 
 	data() {

--- a/src/fields/optional/fieldPikaday.vue
+++ b/src/fields/optional/fieldPikaday.vue
@@ -8,6 +8,7 @@ import { defaults } from "lodash";
 import dateFieldHelper from "../../utils/dateFieldHelper";
 
 export default {
+	name: "field-pikaday",
 	mixins: [abstractField],
 	data() {
 		return { picker: null };

--- a/src/fields/optional/fieldRangeSlider.vue
+++ b/src/fields/optional/fieldRangeSlider.vue
@@ -8,6 +8,7 @@ import abstractField from "../abstractField";
 import { defaults, isArray } from "lodash";
 
 export default {
+	name: "field-rangeSlider",
 	mixins: [abstractField],
 
 	data() {

--- a/src/fields/optional/fieldSelectEx.vue
+++ b/src/fields/optional/fieldSelectEx.vue
@@ -10,6 +10,7 @@ import { isObject } from "lodash";
 import abstractField from "../abstractField";
 
 export default {
+	name: "field-selectex",
 	mixins: [abstractField],
 
 	computed: {

--- a/src/fields/optional/fieldSpectrum.vue
+++ b/src/fields/optional/fieldSpectrum.vue
@@ -7,6 +7,7 @@
 import abstractField from "../abstractField";
 import { defaults } from "lodash";
 export default {
+	name: "field-spectrum",
 	mixins: [abstractField],
 
 	data() {

--- a/src/fields/optional/fieldStaticMap.vue
+++ b/src/fields/optional/fieldStaticMap.vue
@@ -7,6 +7,7 @@ import abstractField from "../abstractField";
 import { defaults } from "lodash";
 
 export default {
+	name: "field-staticmap",
 	mixins: [abstractField],
 
 	computed: {

--- a/src/fields/optional/fieldSwitch.vue
+++ b/src/fields/optional/fieldSwitch.vue
@@ -9,6 +9,7 @@
 import abstractField from "../abstractField";
 
 export default {
+	name: "field-switch",
 	mixins: [abstractField],
 
 	methods: {

--- a/src/fields/optional/fieldVueMultiSelect.vue
+++ b/src/fields/optional/fieldVueMultiSelect.vue
@@ -48,6 +48,7 @@
 import abstractField from "../abstractField";
 
 export default {
+	name: "field-vueMultiSelect",
 	mixins: [abstractField],
 	computed: {
 		options() {

--- a/src/formElement.vue
+++ b/src/formElement.vue
@@ -25,11 +25,9 @@
 import { get as objGet, isArray, isFunction, isNil } from "lodash";
 import { slugifyFormID } from "./utils/schema";
 import formMixin from "./formMixin.js";
-import fieldComponents from "./utils/fieldsLoader.js";
 
 export default {
 	name: "form-element",
-	components: fieldComponents,
 	mixins: [formMixin],
 	props: {
 		model: {

--- a/src/formGenerator.vue
+++ b/src/formGenerator.vue
@@ -46,7 +46,7 @@ import formGroup from "./formGroup.vue";
 import formElement from "./formElement.vue";
 
 export default {
-	name: "formGenerator",
+	name: "form-generator",
 	components: { formGroup, formElement },
 	props: {
 		schema: {

--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,23 @@
-const component = require("./formGenerator.vue").default;
-const schema = require("./utils/schema.js");
-const validators = require("./utils/validators.js").default;
-const fieldComponents = require("./utils/fieldsLoader.js").default;
-const abstractField = require("./fields/abstractField.js").default;
-const install = (Vue) => {
-	Vue.component("VueFormGenerator", module.exports.component);
+import component from "./formGenerator.vue";
+import * as schema from "./utils/schema.js";
+import validators from "./utils/validators.js";
+import abstractField from "./fields/abstractField.js";
+
+const install = (Vue, options = {}) => {
+	if (options.fields) {
+		options.fields.forEach((field) => {
+			if (typeof field.name !== "undefined") {
+				Vue.component(field.name, field);
+			}
+		});
+	}
+	Vue.component("VueFormGenerator", component);
 };
 
-module.exports = {
+export default {
 	component,
 	schema,
 	validators,
 	abstractField,
-	fieldComponents,
 	install
 };

--- a/src/utils/fieldsLoader.js
+++ b/src/utils/fieldsLoader.js
@@ -1,21 +1,49 @@
-let fieldComponents = {};
+// core
+import fieldCheckbox from "../fields/core/fieldCheckbox.vue";
+import fieldChecklist from "../fields/core/fieldChecklist.vue";
+import fieldInput from "../fields/core/fieldInput.vue";
+import fieldLabel from "../fields/core/fieldLabel.vue";
+import fieldRadios from "../fields/core/fieldRadios.vue";
+import fieldSelect from "../fields/core/fieldSelect.vue";
+import fieldSubmit from "../fields/core/fieldSubmit.vue";
+import fieldTextArea from "../fields/core/fieldTextArea.vue";
+import fieldUpload from "../fields/core/fieldUpload.vue";
+// optional
+import fieldCleave from "../fields/optional/fieldCleave.vue";
+import fieldDateTimePicker from "../fields/optional/fieldDateTimePicker.vue";
+import fieldGoogleAddress from "../fields/optional/fieldGoogleAddress.vue";
+import fieldImage from "../fields/optional/fieldImage.vue";
+import fieldMasked from "../fields/optional/fieldMasked.vue";
+import fieldNoUiSlider from "../fields/optional/fieldNoUiSlider.vue";
+import fieldPikaday from "../fields/optional/fieldPikaday.vue";
+import fieldRangeSlider from "../fields/optional/fieldRangeSlider.vue";
+import fieldSelectEx from "../fields/optional/fieldSelectEx.vue";
+import fieldSpectrum from "../fields/optional/fieldSpectrum.vue";
+import fieldStaticMap from "../fields/optional/fieldStaticMap.vue";
+import fieldSwitch from "../fields/optional/fieldSwitch.vue";
+import fieldVueMultiSelect from "../fields/optional/fieldVueMultiSelect.vue";
 
-let coreFields = require.context("../fields/core", false, /^\.\/field([\w-_]+)\.vue$/);
-
-const getCompName = (key) => {
-	return key.replace(/^\.\//, "").replace(/\.vue/, "");
+export {
+	fieldCheckbox,
+	fieldChecklist,
+	fieldInput,
+	fieldLabel,
+	fieldRadios,
+	fieldSelect,
+	fieldSubmit,
+	fieldTextArea,
+	fieldUpload,
+	fieldCleave,
+	fieldDateTimePicker,
+	fieldGoogleAddress,
+	fieldImage,
+	fieldMasked,
+	fieldNoUiSlider,
+	fieldPikaday,
+	fieldRangeSlider,
+	fieldSelectEx,
+	fieldSpectrum,
+	fieldStaticMap,
+	fieldSwitch,
+	fieldVueMultiSelect
 };
-
-coreFields.keys().forEach((key) => {
-	fieldComponents[getCompName(key)] = coreFields(key).default;
-});
-
-if (process.env.VUE_APP_FULL_BUNDLE === "true") {
-	let optionalFields = require.context("../fields/optional", false, /^\.\/field([\w-_]+)\.vue$/);
-
-	optionalFields.keys().forEach((key) => {
-		fieldComponents[getCompName(key)] = optionalFields(key).default;
-	});
-}
-
-export default fieldComponents;

--- a/tests/unit/specs/VueFormGenerator.spec.js
+++ b/tests/unit/specs/VueFormGenerator.spec.js
@@ -2,10 +2,59 @@
 import { mount, createLocalVue } from "@vue/test-utils";
 
 import Vue from "vue";
-import VueFormGenerator from "@/index.js";
+import VueFormGenerator from "@";
+import {
+	fieldCheckbox,
+	fieldChecklist,
+	fieldInput,
+	fieldLabel,
+	fieldRadios,
+	fieldSelect,
+	fieldSubmit,
+	fieldTextArea,
+	fieldUpload,
+	fieldCleave,
+	fieldDateTimePicker,
+	fieldGoogleAddress,
+	fieldImage,
+	fieldMasked,
+	fieldNoUiSlider,
+	fieldPikaday,
+	fieldRangeSlider,
+	fieldSelectEx,
+	fieldSpectrum,
+	fieldStaticMap,
+	fieldSwitch,
+	fieldVueMultiSelect
+} from "@/utils/fieldsLoader.js";
 
 const localVue = createLocalVue();
-localVue.use(VueFormGenerator);
+localVue.use(VueFormGenerator, {
+	fields: [
+		fieldCheckbox,
+		fieldChecklist,
+		fieldInput,
+		fieldLabel,
+		fieldRadios,
+		fieldSelect,
+		fieldSubmit,
+		fieldTextArea,
+		fieldUpload,
+		fieldCleave,
+		fieldDateTimePicker,
+		fieldGoogleAddress,
+		fieldImage,
+		fieldMasked,
+		fieldNoUiSlider,
+		fieldPikaday,
+		fieldRangeSlider,
+		fieldSelectEx,
+		fieldSpectrum,
+		fieldStaticMap,
+		fieldSwitch,
+		fieldVueMultiSelect
+	]
+});
 
 let wrapper;
 const defaultTemplate = `<vue-form-generator :schema="schema" :model="model" :options="options" :multiple="multiple" ref="form"></vue-form-generator>`;

--- a/tests/unit/specs/fields/fieldSelect.spec.js
+++ b/tests/unit/specs/fields/fieldSelect.spec.js
@@ -144,6 +144,9 @@ describe("fieldSelect.vue", () => {
 			type: "select",
 			label: "Cities",
 			model: "city",
+			fieldOptions: {
+				value: "id"
+			},
 			values: [
 				{ id: 1, name: "London" },
 				{ id: 2, name: "Paris" },


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature
- **What is the current behavior?** (You can also link to an open issue here)

#244 
* **What is the new behavior (if this is a feature change)?**

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

There is a new way to deal with fields.
VFG used to register core and/or optionnal fields in Vue (depending on the version you decided to use).
That mean that internally, VFG was using `Vue.component()` to register all fields.
So if you wanted to use only one field or two, your final app had at best, all "core" fields bundled inside.

Now, no fields are added to Vue by default.
You need to pass them as an option.
```js
// Before
import VueFormGenerator from "vue-form-generator";
Vue.use(VueFormGenerator); // All fields are passed through Vue.component()

// Now
import VueFormGenerator from "vue-form-generator";
import {
  fieldCheckbox,
  fieldInput,
  fieldSubmit
} from "vue-form-generator/utils/fieldsLoader.js";
Vue.use(VueFormGenerator, {
  fields: [fieldCheckbox, fieldInput, fieldSubmit] // Only those fields will pass through Vue.component()
});
```
It still work with custom fields. Meaning now, you can use VFG with your custom fields only.
(__If you use a recent version of Webpack or a tool that does tree-shaking__, you should have a better bundle size.
Your custom field will need to have the ["name" property](https://vuejs.org/v2/api/#name) set to "field-***" (e.g. "field-awesome")
```js
import VueFormGenerator from "vue-form-generator";
import fieldAwesome from "./fieldAwesome.vue";
Vue.use(VueFormGenerator, {
  fields: [fieldCheckbox, fieldInput, fieldSubmit] // Only those fields will pass through Vue.component()
});
```
If you want everything like before (full bundle), you need to do that
```js
import VueFormGenerator from "vue-form-generator";
import {
  fieldCheckbox,
  fieldChecklist,
  fieldInput,
  fieldLabel,
  fieldRadios,
  fieldSelect,
  fieldSubmit,
  fieldTextArea,
  fieldUpload,
  fieldCleave,
  fieldDateTimePicker,
  fieldGoogleAddress,
  fieldImage,
  fieldMasked,
  fieldNoUiSlider,
  fieldPikaday,
  fieldRangeSlider,
  fieldSelectEx,
  fieldSpectrum,
  fieldStaticMap,
  fieldSwitch,
  fieldVueMultiSelect
} from "vue-form-generator/utils/fieldsLoader.js";

Vue.use(VueFormGenerator, {
  fields: [
    fieldCheckbox,
    fieldChecklist,
    fieldInput,
    fieldLabel,
    fieldRadios,
    fieldSelect,
    fieldSubmit,
    fieldTextArea,
    fieldUpload,
    fieldCleave,
    fieldDateTimePicker,
    fieldGoogleAddress,
    fieldImage,
    fieldMasked,
    fieldNoUiSlider,
    fieldPikaday,
    fieldRangeSlider,
    fieldSelectEx,
    fieldSpectrum,
    fieldStaticMap,
    fieldSwitch,
    fieldVueMultiSelect
  ]
});
```

* **Other information**:

Be aware that this is the first step toward removing fields from the library and into their own repository.
Soon, VFG will bundle no field at all, and you will need to add them as dependency.

Also, VFG is completely written in ES6 now (`import/export`), no more CommonJS syntax (`require/module.exports`). The mix of both caused a bug in Webpack.