### PR TITLE
formGroup now use the correct class name for error when looking for them

### DIFF
--- a/src/formGroup.vue
+++ b/src/formGroup.vue
@@ -139,7 +139,10 @@ export default {
 	created() {
 		this.eventBus.$on("field-validated", () => {
 			this.$nextTick(() => {
-				let containFieldWithError = this.$refs.group.querySelector(".form-element.error") !== null;
+				let containFieldWithError =
+					this.$refs.group.querySelector(
+						".form-element." + objGet(this.options, "validationErrorClass", "error")
+					) !== null;
 				this.validationClass = {
 					[objGet(this.options, "validationErrorClass", "error")]: containFieldWithError,
 					[objGet(this.options, "validationSuccessClass", "valid")]: !containFieldWithError


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

- **What is the current behavior?** (You can also link to an open issue here)

`form-group` listen for "field-validated" to trigger a search in their DOM childrens for element with a class of ".form-element.error".
If they find some, they apply an error class. If not, they add a validation class.
This is a very basic system to detect error in the children of groups (PR welcome if you have an idea to improve this without it being too costly).
The problem is that the error class can be customize with the option `validationErrorClass`.
The current `querySelector` doen't take this into account.
If you changed `validationErrorClass`, this basic verification system would break and show validation everytime, regardless of the content and state of the children of the group.

* **What is the new behavior (if this is a feature change)?**

It now use `validationErrorClass` to get the error class name.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
