### PR TITLE
Fix required number input does not require a value

### DIFF
--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -1,4 +1,4 @@
-import { defaults, isNil, isNumber, isInteger, isString, isArray, isFunction } from "lodash";
+import { defaults, isNil, isNumber, isInteger, isString, isArray, isFunction, isFinite } from "lodash";
 import fecha from "fecha";
 
 let resources = {
@@ -66,7 +66,7 @@ const validators = {
 		if (res != null) return res;
 
 		let err = [];
-		if (isNumber(value)) {
+		if (isFinite(value)) {
 			if (!isNil(field.min) && value < field.min) {
 				err.push(msg(messages.numberTooSmall, field.min));
 			}

--- a/test/unit/specs/utils/validators.spec.js
+++ b/test/unit/specs/utils/validators.spec.js
@@ -31,6 +31,12 @@ describe("Validators", () => {
 			check(v.number, null, field, 1);
 		});
 
+		it("should give error if value is NaN or Infinity", () => {
+			check(v.number, NaN, field, 1);
+			check(v.number, Infinity, field, 1);
+			check(v.number, -Infinity, field, 1);
+		});
+
 		it("should give error if value is smaller than min", () => {
 			check(v.number, -1, field, 1);
 			check(v.number, 0, field, 1);
@@ -68,7 +74,7 @@ describe("Validators", () => {
 			// invalid integer
 			check(v.integer, 3.14, field, 1);
 			// invalid number, invalid integer
-			check(v.integer, "3.14", field, 2);
+			check(v.integer, NaN, field, 2);
 		});
 
 		it("should not give error if value is integer", () => {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** 
Bug fix.
When using a input of type number that should be required, you actually do not get a validation error.
Instead value in model is set to null.

- **What is the current behavior?** (You can also link to an open issue here)
see https://jsfiddle.net/j04uhscq/17/
=> age field is required but not setting it does not lead to a validation error 

* **What is the new behavior (if this is a feature change)?**

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
Root cause for issue was that a null input becomes a NaN.
Lodash's isNumber (used in number validator) returns true for that, so replaced it by isFinite