### PR TITLE
Fix instantiation of datetimepicker

### DIFF
--- a/src/fields/optional/fieldDateTimePicker.vue
+++ b/src/fields/optional/fieldDateTimePicker.vue
@@ -29,7 +29,7 @@ export default {
 		this.$nextTick(function() {
 			if (window.$ && window.$.fn.datetimepicker) {
 				let input = this.$el.querySelector(".form-control");
-				$(this.$el)
+				$(input)
 					.datetimepicker(
 						defaults(this.schema.dateTimePickerOptions || {}, {
 							format: inputFormat


### PR DESCRIPTION
Well after a little testing and debugging this is what I found. 
datetimepicker should be called on the input element and till now it was called on the 
<div class="form-group valid col-md-4 col-lg-3 col-sm-6 field-dateTimePicker">
and it should be on:
let input = this.$el.querySelector(".form-control");

* **Please check if the PR fulfills these requirements**

- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- **What is the current behavior?** (You can also link to an open issue here)

* **What is the new behavior (if this is a feature change)?**

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
