### PR TITLE
listen for model-updated from `fields`, and fix `debounceFormatFuncti…

### DIFF
--- a/src/fields/abstractField.js
+++ b/src/fields/abstractField.js
@@ -31,7 +31,7 @@ export default {
 		return {
 			errors: [],
 			debouncedValidateFunc: null,
-			debouncedFormatFunction: null
+			debouncedFormatFunc: null
 		};
 	},
 

--- a/src/formGenerator.vue
+++ b/src/formGenerator.vue
@@ -2,7 +2,7 @@
 div.vue-form-generator(v-if='schema != null')
 	fieldset(v-if="schema.fields", :is='tag')
 		template(v-for='field in fields')
-			form-group(v-if='fieldVisible(field)', :vfg="vfg", :field="field", :errors="errors", :model="model", :options="options", @validated="onFieldValidated")
+			form-group(v-if='fieldVisible(field)', :vfg="vfg", :field="field", :errors="errors", :model="model", :options="options", @validated="onFieldValidated", @model-updated="onModelUpdated")
 
 	template(v-for='group in groups')
 		fieldset(:is='tag', :class='getFieldRowClasses(group)')


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fixes the bug reported in #554 

- **What is the current behavior?** (You can also link to an open issue here)
'model-updated' is not called when using 'fields', but works when using 'groups'

* **What is the new behavior (if this is a feature change)?**
'model-updated' is emitted for both 'fields' and 'groups'

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

* Refer to #554 for details
* Also changed 'debouncedFormatFunction' to be 'debouncedFormatFunc' to follow naming convention of 'debouncedValidateFunc' and 'formInput' already used 'debouncedFormatFunc' (likely with warnings/errors since it was declared incorrectly).