### PR TITLE
added "type" attribute to inside buttons schema, defaults to "button"…

### DIFF
--- a/src/formGroup.vue
+++ b/src/formGroup.vue
@@ -11,7 +11,7 @@
 		<div class="field-wrap">
 			<component ref="child" :is="getFieldType(field)" :vfg="vfg" :disabled="fieldDisabled(field)" :model="model" :schema="field" :formOptions="options" @model-updated="onModelUpdated" @validated="onFieldValidated"></component>
 			<div v-if="buttonVisibility(field)" class="buttons">
-				<button v-for="(btn, index) in field.buttons" @click="buttonClickHandler(btn, field, $event)" :class="btn.classes" :key="index" v-text="btn.label"></button>
+				<button v-for="(btn, index) in field.buttons" @click="buttonClickHandler(btn, field, $event)" :class="btn.classes" :key="index" v-text="btn.label" :type="getButtonType(btn)"></button>
 			</div>
 		</div>
 
@@ -80,6 +80,10 @@ export default {
 		// Get type of field 'field-xxx'. It'll be the name of HTML element
 		getFieldType(fieldSchema) {
 			return "field-" + fieldSchema.type;
+		},
+		// Get type of button, default to 'button'
+		getButtonType(btn) {
+			return objGet(btn, 'type', 'button');
 		},
 		// Child field executed validation
 		onFieldValidated(res, errors, field) {

--- a/src/formGroup.vue
+++ b/src/formGroup.vue
@@ -83,7 +83,7 @@ export default {
 		},
 		// Get type of button, default to 'button'
 		getButtonType(btn) {
-			return objGet(btn, 'type', 'button');
+			return objGet(btn, "type", "button");
 		},
 		// Child field executed validation
 		onFieldValidated(res, errors, field) {


### PR DESCRIPTION
… when one is not provided

* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Introduces a "type" attribute to "inside buttons" and defaults to "button" when not provided

- **What is the current behavior?** (You can also link to an open issue here)
User can not set the "type" of an inside button

* **What is the new behavior (if this is a feature change)?**
User can set the "type" of an inside button

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
It should not

* **Other information**:
Fixes #292 