### PR TITLE
added "options" to VFG install function, appending custom "validators…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,8 +3,13 @@ const schema = require("./utils/schema.js");
 const validators = require("./utils/validators.js").default;
 const fieldComponents = require("./utils/fieldsLoader").default;
 const abstractField = require("./fields/abstractField").default;
-const install = (Vue) => {
+const install = (Vue, options) => {
 	Vue.component("VueFormGenerator", module.exports.component);
+	if(options && options.validators) {
+		for(let key in options.validators) {
+			validators[key] = options.validators[key];
+		}
+	}
 };
 
 module.exports = {

--- a/src/index.js
+++ b/src/index.js
@@ -5,9 +5,11 @@ const fieldComponents = require("./utils/fieldsLoader").default;
 const abstractField = require("./fields/abstractField").default;
 const install = (Vue, options) => {
 	Vue.component("VueFormGenerator", module.exports.component);
-	if(options && options.validators) {
-		for(let key in options.validators) {
-			validators[key] = options.validators[key];
+	if (options && options.validators) {
+		for (let key in options.validators) {
+			if ({}.hasOwnProperty.call(options.validators, key)) {
+				validators[key] = options.validators[key];
+			}
 		}
 	}
 };


### PR DESCRIPTION
…" to the validators object that are passed into `Vue.use(VueFormGenerator, { validators: { key: (value, field, model) => {} })

* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

- **What is the current behavior?** (You can also link to an open issue here)
VFG has a limited number of "built-in" validators, and custom validators require a reference to the function which is not possible when using JSON returned from the server.

* **What is the new behavior (if this is a feature change)?**
Introduce the ability to modify the "built-in validators" when calling `Vue.use(VueFormGenerator)` by passing an options object with the validators.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No
* **Other information**:
Resolves #545 

Example usage:
```
import Vue from "vue";
import VueFormGenerator from "../../../src";
Vue.use(VueFormGenerator, {
	validators: {
		customValidator: (value, field, model) => {
			console.log("customValidator", value, field, model);
			return true;
		}
	}
});

import App from "./app.vue";

new Vue({
	...App
}).$mount("#app");
```