### PR TITLE
fixes an issue with fieldPikaday modifying the field schema and attac…

### DIFF
--- a/src/fields/optional/fieldPikaday.vue
+++ b/src/fields/optional/fieldPikaday.vue
@@ -20,7 +20,7 @@ export default {
 
 	methods: {
 		getDateFormat() {
-			return objGet(this.schema, 'pikadayOptions.format', inputFormat);
+			return objGet(this.schema, "pikadayOptions.format", inputFormat);
 		},
 		...dateFieldHelper,
 		initialize(options) {

--- a/src/fields/optional/fieldPikaday.vue
+++ b/src/fields/optional/fieldPikaday.vue
@@ -4,46 +4,56 @@
 
 <script>
 import abstractField from "../abstractField";
-import { defaults } from "lodash";
+import { defaults, get as objGet } from "lodash";
 import dateFieldHelper from "../../utils/dateFieldHelper";
 
 let inputFormat = "YYYY-MM-DD";
 
 export default {
-	mixins: [abstractField],
+	mixins: [ abstractField ],
 	data() {
-		return { picker: null };
+		return { 
+			picker: null,
+			options: null
+		};
 	},
 
 	methods: {
 		getDateFormat() {
-			if (this.schema.pikadayOptions && this.schema.pikadayOptions.format) return this.schema.pikadayOptions.format;
-			else return inputFormat;
+			return objGet(this.schema, 'pikadayOptions.format', inputFormat);
 		},
+		...dateFieldHelper,
+		initialize(options) {
+			if(this.picker && this.picker.destroy) {
+				// if an existing picker is already set, destroy it first
+				this.picker.destroy();
+			}
 
-		...dateFieldHelper
-	},
-
-	mounted() {
-		this.$nextTick(() => {
-			if (window.Pikaday) {
-				this.picker = new window.Pikaday(
-					defaults(this.schema.pikadayOptions || {}, {
+			this.$nextTick(() => {
+				if (window.Pikaday) {
+					this.options = defaults({}, options, {
 						field: this.$el, // bind the datepicker to a form field
 						onSelect: () => {
 							this.value = this.picker.toString();
 						}
 						// trigger: , // use a different element to trigger opening the datepicker, see [trigger example][] (default to `field`)
-					})
-				);
-			} else {
-				console.warn("Pikaday is missing. Please download from https://github.com/dbushell/Pikaday/ and load the script and CSS in the HTML head section!");
-			}
-		});
+					});
+					this.picker = new window.Pikaday(this.options);
+				} else {
+					console.warn("Pikaday is missing. Please download from https://github.com/dbushell/Pikaday/ and load the script and CSS in the HTML head section!");
+				}
+			});
+		}
+	},
+
+	mounted() {
+		this.initialize(objGet(this.schema, "pikadayOptions", {}));
 	},
 
 	beforeDestroy() {
-		if (this.picker) this.picker.destroy();
+		if (this.picker) {
+			this.picker.destroy();
+		}
 	}
 };
 </script>


### PR DESCRIPTION
…hing `this.$el` to it, the pikadayOptions are now stored as `this.options` and created with `defaults({}, this.schema.pikadayOptions, {...})` to prevent this

* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix 

- **What is the current behavior?** (You can also link to an open issue here)
fieldPikaday modifies the fields schema by using lodash's `defaults`

* **What is the new behavior (if this is a feature change)?**
fieldPikaday now stores the modified options as `this.options` without modifying the field's schema

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No, it should not
* **Other information**:
Fixes #561 