### PR TITLE
migrated VFG docs to newer GitBooks, created GitHub Repo for Docs to …

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ A schema-based form generator component for Vue.js.
 
 ## Demo
 
-[JSFiddle simple example](https://jsfiddle.net/icebob/0mg1v81e/)
+[JSFiddle simple example](https://jsfiddle.net/zoul0813/d8excp36/)
+[CodePen simple example](https://codepen.io/zoul0813/pen/OrNVNw)
 
-[![Screenshot](https://icebob.gitbooks.io/vueformgenerator/content/assets/vfg-example1.png)](https://jsfiddle.net/icebob/0mg1v81e/)
+[![Screenshot](https://github.com/vue-generators/vue-form-generator-docs/raw/master/assets/vfg-example1.png)](https://jsfiddle.net/zoul0813/d8excp36/)
 
 ## Features
 
@@ -33,7 +34,7 @@ A schema-based form generator component for Vue.js.
 
 ## Documentation
 
-[Online documentation on Gitbook](https://icebob.gitbooks.io/vueformgenerator/content/)
+[Online documentation on Gitbook](https://vue-generators.gitbook.io/vue-generators/)
 
 ## Dependencies
 
@@ -43,7 +44,7 @@ While built-in fields don't need external dependencies, optional fields may need
 These dependencies fall into two camps: jQuery or Vanilla. You can find almost the same functionality in both flavors.
 In the end, it's your choice to depend on jQuery or not.
 
-You can find details about dependencies in the official [documentation](https://icebob.gitbooks.io/vueformgenerator/content/) under each specific component.
+You can find details about dependencies in the official [documentation](https://vue-generators.gitbook.io/vue-generators/) under each specific component.
 
 ## Installation
 


### PR DESCRIPTION
…allow for easier maintenance, updated JSFiddle to use "latest" VFG, and created a CodePen version as well

* **Please check if the PR fulfills these requirements**

- [X] The commit message follows our guidelines
- [X] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Docs Update

- **What is the current behavior?** (You can also link to an open issue here)
Docs currently point to a JSFiddle that is no longer up-to-date (v2.2.1) and the core documentation is hosted on Legacy GitBooks.

* **What is the new behavior (if this is a feature change)?**
JSFiddle has been updated and now points to the "latest" version of VFG (and should auto-update as it's no longer bound to a specific version).

Migrated the Legacy GitBooks documentation over to the vue-form-generator-docs repo, and synced this repo with a new GitBooks account that will auto-update from the GitHub repo.  Documentation can now be updated through GitHub PR's and should hopefully stay more up to date.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:

If you'd like to be added to the GitBook Team, send me a message with your email address.  Apparently I can't just add GitHub users by username to the team.  It requires me to send an "invite link".