### PR TITLE
#551 - added "is-disabled" class to the radios label

### DIFF
--- a/src/fields/core/fieldRadios.vue
+++ b/src/fields/core/fieldRadios.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
 	.radio-list(:disabled="disabled", v-attributes="'wrapper'")
-		label(v-for="item in items", :class="{'is-checked': isItemChecked(item)}", v-attributes="'label'")
+		label(v-for="item in items", :class="getItemCssClasses(item)", v-attributes="'label'")
 			input(:id="getFieldID(schema, true)", type="radio", :disabled="isItemDisabled(item)", :name="id", @click="onSelection(item)", :value="getItemValue(item)", :checked="isItemChecked(item)", :class="schema.fieldClasses", :required="schema.required", v-attributes="'input'")
 			| {{ getItemName(item) }}
 
@@ -57,6 +57,12 @@ export default {
 			} else {
 				return item;
 			}
+		},
+		getItemCssClasses(item) {
+			return {
+				"is-checked": this.isItemChecked(item),
+				"is-disabled": this.isItemDisabled(item)
+			};
 		},
 		onSelection(item) {
 			this.value = this.getItemValue(item);


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature 

- **What is the current behavior?** (You can also link to an open issue here)
No CSS class is attached to the label element for disabled state

* **What is the new behavior (if this is a feature change)?**
An `is-disabled` CSS class is attached to the radio option label to allow you to style the element based on it's `item.disabled` state.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
Additional feature from #551 