### PR TITLE
added optional field property `debounceValidateTime` which works at t…

### DIFF
--- a/src/fields/abstractField.js
+++ b/src/fields/abstractField.js
@@ -139,7 +139,7 @@ export default {
 			if (!isFunction(this.debouncedValidateFunc)) {
 				this.debouncedValidateFunc = debounce(
 					this.validate.bind(this),
-					objGet(this.schema, 'validateDebounceTime', objGet(this.formOptions, 'validateDebounceTime', 500))
+					objGet(this.schema, "validateDebounceTime", objGet(this.formOptions, "validateDebounceTime", 500))
 				);
 			}
 			this.debouncedValidateFunc();
@@ -163,7 +163,7 @@ export default {
 				}
 
 				if (objGet(this.formOptions, "validateAfterChanged", false) === true) {
-					if (objGet(this.schema, 'validateDebounceTime', objGet(this.formOptions, 'validateDebounceTime', 0)) > 0) {
+					if (objGet(this.schema, "validateDebounceTime", objGet(this.formOptions, "validateDebounceTime", 0)) > 0) {
 						this.debouncedValidate();
 					} else {
 						this.validate();

--- a/src/fields/abstractField.js
+++ b/src/fields/abstractField.js
@@ -139,7 +139,7 @@ export default {
 			if (!isFunction(this.debouncedValidateFunc)) {
 				this.debouncedValidateFunc = debounce(
 					this.validate.bind(this),
-					objGet(this, "$parent.options.validateDebounceTime", 500)
+					objGet(this.schema, 'validateDebounceTime', objGet(this.formOptions, 'validateDebounceTime', 500))
 				);
 			}
 			this.debouncedValidateFunc();
@@ -162,8 +162,8 @@ export default {
 					this.schema.onChanged.call(this, this.model, newValue, oldValue, this.schema);
 				}
 
-				if (objGet(this.$parent, "options.validateAfterChanged", false) === true) {
-					if (objGet(this.$parent, "options.validateDebounceTime", 0) > 0) {
+				if (objGet(this.formOptions, "validateAfterChanged", false) === true) {
+					if (objGet(this.schema, 'validateDebounceTime', objGet(this.formOptions, 'validateDebounceTime', 0)) > 0) {
 						this.debouncedValidate();
 					} else {
 						this.validate();

--- a/src/formGenerator.vue
+++ b/src/formGenerator.vue
@@ -30,8 +30,9 @@ export default {
 			default() {
 				return {
 					validateAfterLoad: false,
-					validateAsync: false,
 					validateAfterChanged: false,
+					fieldIdPrefix: '',
+					validateAsync: false,
 					validationErrorClass: "error",
 					validationSuccessClass: ""
 				};

--- a/src/formGenerator.vue
+++ b/src/formGenerator.vue
@@ -31,7 +31,7 @@ export default {
 				return {
 					validateAfterLoad: false,
 					validateAfterChanged: false,
-					fieldIdPrefix: '',
+					fieldIdPrefix: "",
 					validateAsync: false,
 					validationErrorClass: "error",
 					validationSuccessClass: ""

--- a/test/unit/specs/fields/abstractField.spec.js
+++ b/test/unit/specs/fields/abstractField.spec.js
@@ -213,6 +213,8 @@ describe("abstractField.vue", () => {
 
 		it("should call validate function after value changed", () => {
 			options.validateAfterChanged = true;
+			// seems to be an issue with how the field is defined, the update to 'options' isn't carried over to field.formOptions
+			field.formOptions = options;
 			field.value = "Jane Roe";
 
 			expect(field.validate.callCount).to.be.equal(1);


### PR DESCRIPTION
…he field level, allowing individual fields to be debounced as opposed to the entire schema.  works the same as `formOptions.debounceValidateTime`

* **Please check if the PR fulfills these requirements**

- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature

- **What is the current behavior?** (You can also link to an open issue here)
Fields do not have individual 'debounce' logic for validation, the schema does however.

* **What is the new behavior (if this is a feature change)?**
Fields can now have their own debounced time set, allowing the developer to change the debounce delay at the field level.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No - this should be backwards compatible with the existing `debounceValidateTime` formOption and just extends it.

* **Other information**:

GitBook docs were updated to add the `validateDebounceTime` formOption, as well as reference this new feature.

I also removed the references to `this.$parent` and updated it to use `this.formOptions` instead, so this feature should not be affected by Vue hierarchy changes in the future.

The feature defaults to using the field schema, and falls back to the formOptions option with a default of 0 (no delay).