### PR TITLE
Invalide date check in validators.js

### DIFF
--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -149,7 +149,7 @@ const validators = {
 		if (res != null) return res;
 
 		let m = new Date(value);
-		if (!m) {
+		if (isNaN(m.getDate())) {
 			return [msg(messages.invalidDate)];
 		}
 


### PR DESCRIPTION
- ***What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)***
bug fix
- ***What is the current behavior? (You can also link to an open issue here)***
new Date('wrong string') return a string `Invalid Date` which is not usable with boolean negation.

- ***What is the new behavior (if this is a feature change)?***
The check will use isNan to the getDate() function instead

- ***Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)***
No