### PR TITLE
Group visibility control

### DIFF
--- a/src/formGenerator.vue
+++ b/src/formGenerator.vue
@@ -5,7 +5,7 @@ div.vue-form-generator(v-if='schema != null')
 			form-group(v-if='fieldVisible(field)', :vfg="vfg", :field="field", :errors="errors", :model="model", :options="options", @validated="onFieldValidated", @model-updated="onModelUpdated")
 
 	template(v-for='group in groups')
-		fieldset(:is='tag', :class='getFieldRowClasses(group)')
+		fieldset(v-if='groupVisible(group)' :is='tag', :class='getFieldRowClasses(group)')
 			legend(v-if='group.legend') {{ group.legend }}
 			template(v-for='field in group.fields')
 				form-group(v-if='fieldVisible(field)', :vfg="vfg", :field="field", :errors="errors", :model="model", :options="options", @validated="onFieldValidated", @model-updated="onModelUpdated")
@@ -129,6 +129,15 @@ export default {
 			if (isNil(field.visible)) return true;
 
 			return field.visible;
+		},
+
+		// Get visible prop of field group
+		groupVisible(group) {
+			if (isFunction(group.visible)) return group.visible.call(this, this.model, group, this);
+
+			if (isNil(group.visible)) return true;
+
+			return group.visible;
 		},
 
 		// Child field executed validation


### PR DESCRIPTION
Simple, but perhaps naïve change to permit `visible` control for groups same as for fields.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Ability to control visibility of field groups.

- **What is the current behavior?** (You can also link to an open issue here)
Groups visibility cannot be controlled. Groups are always rendered.

* **What is the new behavior (if this is a feature change)?**
Specifying `visible` attribute on a field group permits to control group visibility.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Don't think so.
