### PR TITLE
Add slots for fields and groups

### DIFF
--- a/src/formGenerator.vue
+++ b/src/formGenerator.vue
@@ -1,14 +1,16 @@
 <template lang="pug">
 div.vue-form-generator(v-if='schema != null')
-	fieldset(v-if="schema.fields", :is='tag')
-		template(v-for='field in fields')
-			form-group(v-if='fieldVisible(field)', :vfg="vfg", :field="field", :errors="errors", :model="model", :options="options", @validated="onFieldValidated", @model-updated="onModelUpdated")
-
-	template(v-for='group in groups')
-		fieldset(:is='tag', :class='getFieldRowClasses(group)')
-			legend(v-if='group.legend') {{ group.legend }}
-			template(v-for='field in group.fields')
+	slot(name="fields" v-bind="{ fields, errors, options, model }")
+		fieldset(v-if="schema.fields", :is='tag')
+			template(v-for='field in fields')
 				form-group(v-if='fieldVisible(field)', :vfg="vfg", :field="field", :errors="errors", :model="model", :options="options", @validated="onFieldValidated", @model-updated="onModelUpdated")
+
+	slot(name="groups" v-bind="{ groups, errors, options, model }")
+		template(v-for='group in groups')
+			fieldset(:is='tag', :class='getFieldRowClasses(group)')
+				legend(v-if='group.legend') {{ group.legend }}
+					template(v-for='field in group.fields')
+						form-group(v-if='fieldVisible(field)', :vfg="vfg", :field="field", :errors="errors", :model="model", :options="options", @validated="onFieldValidated", @model-updated="onModelUpdated")
 </template>
 
 <script>


### PR DESCRIPTION
## Flexible groups and fields rendering using slots.

* **What kind of change does this PR introduce?**
It's just a PoC for a feature to add slots for groups and fields.

- **What is the current behaviour?**
You can not change the way groups or fields are rendered.

* **What is the new behaviour?**
You may pass the appropriate slot to apply custom rendering.
```html
<vue-form-generator :schema="schema" :model="model" :options="formOptions">
    <template v-slot:groups="{ groups }">
        ...
    </template>
</vue-form-generator>
```

- **Does this PR introduce a breaking change?**
No.

* **Other information**:
Would love to get some feedback and possibly to know if this is something you'd even consider?