### PR TITLE
Fix fieldComponents exposure

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 const component = require("./formGenerator.vue").default;
 const schema = require("./utils/schema.js");
 const validators = require("./utils/validators.js").default;
-const fieldComponents = require("./utils/fieldsLoader").default;
+const fieldComponents = require("./utils/fieldsLoader");
 const abstractField = require("./fields/abstractField").default;
 const install = (Vue, options) => {
 	Vue.component("VueFormGenerator", module.exports.component);


### PR DESCRIPTION
Exposing fieldComponents was broken because we were exporting named
exports in the `fieldsLoader.js` while we were importing as though it was exported as a default export.

* **Please check if the PR fulfills these requirements**

- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)

In export (`utils/fieldsLoader.js`):

```javascript
module.exports = fieldComponents;
```

In import time inside (`index.js`)

```js
const fieldComponents = require("./utils/fieldsLoader").default;
```

This meant that this code would not be doing the right thing.

```js
import { fieldComponents } from 'vue-form-generator'
```
Because 

```js
// fieldComponents === undefined; because we imported it as if it was a default export
```

I'm sure this is not intended.

`fieldComponents` would always be `undefined`, which isn't very nice because for some
usecases, you might actually want to have access to the components.

* **What is the new behavior (if this is a feature change)?**

Changes the importing to 
```js
const fieldComponents = require("./utils/fieldsLoader");
```


- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No breaking changes introduced.

* **Other information**:

Nothing else to add.