### PR TITLE
Fix issue #609

### DIFF
--- a/src/utils/dateFieldHelper.js
+++ b/src/utils/dateFieldHelper.js
@@ -13,6 +13,11 @@ export default {
 	formatValueToModel(value) {
 		if (value != null) {
 			let m = fecha.parse(value, this.getDateFormat());
+			
+		    if (m == null) {
+			  return null
+		    }
+			
 			if (this.schema.format) {
 				value = fecha.format(m, this.schema.format);
 			} else {


### PR DESCRIPTION
formatValueToModel should wait to have a valid date before trying to format the field. In this way the user can both use the UI and use the manual input to submit a date.