### PR TITLE
v3 Enable lodash 'paths' feature

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -62,7 +62,7 @@ module.exports = {
 					memoizing: true,
 					coercions: true,
 					flattening: true,
-					paths: false,
+					paths: true,
 					placeholders: true
 				}
 			]);


### PR DESCRIPTION
According to the documentation, most features were turned off
by default to reduce the package size. In order to use your desired
feature, you needed to opt in to it.

'paths' feature was set to false. According to lodash documentation, `paths` feature offers *Deep property path support for methods like `_.get, _.has, & _.set`*. If the feature is not enabled, deep property fetching will fail since the methods are replaced with a `_.noop` method that always returns `undefined`.

Field attributes depend on this functionality in order to get `attributes.label`, `attributes.input` and `attributes.wrapper`. I also have fields with models like `foo.bar` which means that these fields will not work since we are able to set the value, but not get the value.

Therefore, I have enabled this option so that we can be sure that vfg.abstractField's value property will always be working whether the model provided is a deep or shallow path.

* **Please check if the PR fulfills these requirements**

- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Enables lodash's path feature.

- **What is the current behavior?** (You can also link to an open issue here)
Trying to access attributes from a hash using a path notation like `foo.bar` returns `undefined`.

* **What is the new behavior (if this is a feature change)?**

if I have an object:
```
let foo = {
    bar: {
        baz: 'boo'
    } 
};

 _.get(foo, 'bar.baz'); // will return 'boo'

```
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

NO.