### PR TITLE
V3 fix simple bugs

### DIFF
--- a/src/formElement.vue
+++ b/src/formElement.vue
@@ -24,7 +24,7 @@
 				:schema="field"
 				:form-options="options"
 				:event-bus="eventBus"
-				:field-id="fieldID"
+				:field-i-d="fieldID"
 				@field-touched="onFieldTouched"
 				@errors-updated="onChildValidated"></component>
 			<div

--- a/src/formElement.vue
+++ b/src/formElement.vue
@@ -16,28 +16,26 @@
 				:getValueFromOption="getValueFromOption"></slot>
 		</label>
 
-		<div class="field-content">
-			<div class="field-wrap">
-				<component
-					ref="child"
-					:is="fieldType"
-					:model="model"
-					:schema="field"
-					:form-options="options"
-					:event-bus="eventBus"
-					:field-i-d="fieldID"
-					@field-touched="onFieldTouched"
-					@errors-updated="onChildValidated"></component>
-				<div
-					v-if="buttonsAreVisible"
-					class="buttons">
-					<button
-						v-for="(btn, index) in field.buttons"
-						@click="buttonClickHandler(btn, field, $event)"
-						:class="btn.classes"
-						:key="index"
-						v-text="btn.label"></button>
-				</div>
+		<div class="field-wrap">
+			<component
+				ref="child"
+				:is="fieldType"
+				:model="model"
+				:schema="field"
+				:form-options="options"
+				:event-bus="eventBus"
+				:field-id="fieldID"
+				@field-touched="onFieldTouched"
+				@errors-updated="onChildValidated"></component>
+			<div
+				v-if="buttonsAreVisible"
+				class="buttons">
+				<button
+					v-for="(btn, index) in field.buttons"
+					@click="buttonClickHandler(btn, field, $event)"
+					:class="btn.classes"
+					:key="index"
+					v-text="btn.label"></button>
 			</div>
 		</div>
 

--- a/src/formElement.vue
+++ b/src/formElement.vue
@@ -16,26 +16,28 @@
 				:getValueFromOption="getValueFromOption"></slot>
 		</label>
 
-		<div class="field-wrap">
-			<component
-				ref="child"
-				:is="fieldType"
-				:model="model"
-				:schema="field"
-				:form-options="options"
-				:event-bus="eventBus"
-				:field-id="fieldID"
-				@field-touched="onFieldTouched"
-				@errors-updated="onChildValidated"></component>
-			<div
-				v-if="buttonsAreVisible"
-				class="buttons">
-				<button
-					v-for="(btn, index) in field.buttons"
-					@click="buttonClickHandler(btn, field, $event)"
-					:class="btn.classes"
-					:key="index"
-					v-text="btn.label"></button>
+		<div class="field-content">
+			<div class="field-wrap">
+				<component
+					ref="child"
+					:is="fieldType"
+					:model="model"
+					:schema="field"
+					:form-options="options"
+					:event-bus="eventBus"
+					:field-i-d="fieldID"
+					@field-touched="onFieldTouched"
+					@errors-updated="onChildValidated"></component>
+				<div
+					v-if="buttonsAreVisible"
+					class="buttons">
+					<button
+						v-for="(btn, index) in field.buttons"
+						@click="buttonClickHandler(btn, field, $event)"
+						:class="btn.classes"
+						:key="index"
+						v-text="btn.label"></button>
+				</div>
 			</div>
 		</div>
 

--- a/src/formGenerator.vue
+++ b/src/formGenerator.vue
@@ -289,7 +289,10 @@ export default {
 			this.eventBus.$on("field-validated", this.onFieldValidated);
 		}
 		this.eventBus.$on("model-updated", this.onModelUpdated);
-		this.eventBus.$on("fields-validation-trigger", this.validate);
+		//this.eventBus.$on("fields-validation-trigger", this.validate);
+		this.eventBus.$on("fields-validation-trigger", () => {
+			return this.validate().then(() => {}, () => {});
+		});
 		this.eventBus.$on("field-registering", () => {
 			this.totalNumberOfFields = this.totalNumberOfFields + 1;
 		});

--- a/src/formGenerator.vue
+++ b/src/formGenerator.vue
@@ -242,7 +242,6 @@ export default {
 				let formErrors = [];
 
 				this.eventBus.$on("field-deregistering", () => {
-					// console.warn("Fields were deleted during validation process");
 					this.eventBus.$emit("fields-validation-terminated", formErrors);
 					reject(formErrors);
 				});
@@ -289,7 +288,6 @@ export default {
 			this.eventBus.$on("field-validated", this.onFieldValidated);
 		}
 		this.eventBus.$on("model-updated", this.onModelUpdated);
-		//this.eventBus.$on("fields-validation-trigger", this.validate);
 		this.eventBus.$on("fields-validation-trigger", () => {
 			return this.validate().then(() => {}, () => {});
 		});

--- a/tests/unit/specs/VueFormGenerator.spec.js
+++ b/tests/unit/specs/VueFormGenerator.spec.js
@@ -918,31 +918,38 @@ describe("VueFormGenerator.vue", () => {
 
 		it("should be validation error if model value is not valid", () => {
 			formGenerator.setProps({ model: { name: "A" } });
-			form.validate();
-
-			expect(form.errors).to.be.length(1);
-			expect(formGenerator.emitted().validated).to.be.an.instanceof(Array);
-			expect(formGenerator.emitted().validated.length).to.be.equal(1);
-			expect(formGenerator.emitted().validated[0][0]).to.be.false;
-			expect(formGenerator.emitted().validated[0][1]).to.be.an.instanceof(Array);
-			expect(formGenerator.emitted().validated[0][1].length).to.be.equal(1);
-			expect(formGenerator.emitted().validated[0][1][0].uid).to.be.a("string");
-			expect(formGenerator.emitted().validated[0][1][0].error).to.be.a("string");
-			expect(formGenerator.emitted().validated[0][1][0].error).to.be.equal(
-				"The length of text is too small! Current: 1, Minimum: 3"
+			form.validate().then(
+				() => {
+					console.log(JSON.stringify(form.errors));
+					expect(form.errors).to.be.length(1);
+					expect(formGenerator.emitted().validated).to.be.an.instanceof(Array);
+					expect(formGenerator.emitted().validated.length).to.be.equal(1);
+					expect(formGenerator.emitted().validated[0][0]).to.be.false;
+					expect(formGenerator.emitted().validated[0][1]).to.be.an.instanceof(Array);
+					expect(formGenerator.emitted().validated[0][1].length).to.be.equal(1);
+					expect(formGenerator.emitted().validated[0][1][0].uid).to.be.a("string");
+					expect(formGenerator.emitted().validated[0][1][0].error).to.be.a("string");
+					expect(formGenerator.emitted().validated[0][1][0].error).to.be.equal(
+						"The length of text is too small! Current: 1, Minimum: 3"
+					);
+				},
+				() => {}
 			);
 		});
 
 		it("should no validation error if model valie is valid", () => {
 			formGenerator.setProps({ model: { name: "Alan" } });
-			form.validate();
-
-			expect(form.errors).to.be.length(0);
-			expect(formGenerator.emitted().validated).to.be.an.instanceof(Array);
-			expect(formGenerator.emitted().validated.length).to.be.equal(1);
-			expect(formGenerator.emitted().validated[0][0]).to.be.true;
-			expect(formGenerator.emitted().validated[0][1]).to.be.an.instanceof(Array);
-			expect(formGenerator.emitted().validated[0][1].length).to.be.equal(0);
+			form.validate().then(
+				() => {
+					expect(form.errors).to.be.length(0);
+					expect(formGenerator.emitted().validated).to.be.an.instanceof(Array);
+					expect(formGenerator.emitted().validated.length).to.be.equal(1);
+					expect(formGenerator.emitted().validated[0][0]).to.be.true;
+					expect(formGenerator.emitted().validated[0][1]).to.be.an.instanceof(Array);
+					expect(formGenerator.emitted().validated[0][1].length).to.be.equal(0);
+				},
+				() => {}
+			);
 		});
 	});
 
@@ -1030,7 +1037,7 @@ describe("VueFormGenerator.vue", () => {
 		it.skip("should be validation error if model value is not valid", () => {
 			onValidated.resetHistory();
 			wrapper.vm.model.name = "A";
-			field.validate();
+			field.validate().then(() => {}, () => {});
 
 			expect(form.errors).to.be.length(1);
 			expect(onValidated.callCount).to.be.equal(1);
@@ -1045,7 +1052,7 @@ describe("VueFormGenerator.vue", () => {
 		});
 
 		it.skip("should be 2 validation error", () => {
-			form.$children[1].validate();
+			form.$children[1].validate().then(() => {}, () => {});
 			expect(form.errors).to.be.length(2);
 			expect(form.errors[0].error).to.be.equal("The length of text is too small! Current: 1, Minimum: 3");
 			expect(form.errors[1].error).to.be.equal("Validation error!");
@@ -1054,7 +1061,7 @@ describe("VueFormGenerator.vue", () => {
 		it.skip("should only other field validation error", () => {
 			wrapper.vm.model.name = "Alan";
 			onValidated.resetHistory();
-			field.validate();
+			field.validate().then(() => {}, () => {});
 
 			expect(form.errors).to.be.length(1);
 			expect(onValidated.callCount).to.be.equal(1);
@@ -1115,7 +1122,7 @@ describe("VueFormGenerator.vue", () => {
 			onValidated.resetHistory();
 			wrapper.vm.model.name = "A";
 			// console.log(formGenerator.find({ name: "form-element" }).vm.$children[0].validate);
-			field.validate();
+			field.validate().then(() => {}, () => {});
 			Vue.config.errorHandler = done;
 			Vue.nextTick(() => {
 				expect(form.errors).to.be.length(1);

--- a/tests/unit/specs/VueFormGenerator.spec.js
+++ b/tests/unit/specs/VueFormGenerator.spec.js
@@ -920,7 +920,6 @@ describe("VueFormGenerator.vue", () => {
 			formGenerator.setProps({ model: { name: "A" } });
 			form.validate().then(
 				() => {
-					console.log(JSON.stringify(form.errors));
 					expect(form.errors).to.be.length(1);
 					expect(formGenerator.emitted().validated).to.be.an.instanceof(Array);
 					expect(formGenerator.emitted().validated.length).to.be.equal(1);


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

**Fix fieldID prop case**
Wrong casing where `fieldID` prop was passed as `field-id` which
gets resolved as `fieldId` which means that inputs did not receive
the id configured in the schema. Resolved this by passing the component as `field-i-d` which  is resolved to `fieldID`.

**Use Promise success and failure handlers for .validate method**
Previously, the validate() function returned a promise which
would resolve() if there were no validation errors, and reject(errors)
if there were errors. However, when calling this validate method, we called it as the callback
of the "fields-validation-trigger" event.

When this promise is rejected because of validation errors, we
do not have a .catch method to deal with the rejection. This causes
it to get "stuck" and dies in the console. This is unwanted behavior.

The javascript engine will track such unhandled rejections and generate
global errors with the event "unhandledrejection".

This fills the console with "errors" which aren't actual execution errors.

The solution I had here was to update the code to always use resolve. If there
are errors, we resolve with the errors, if there are no errors, we resolve with
undefined/null.

The solution I implemented here is to include empty functions success and failure
handlers.


- **What is the current behavior?** (You can also link to an open issue here)
1. `fieldID` in the rendered fields is `undefined`.
2. When there is a validation error, javascript errors are thrown in the console log.

* **What is the new behavior (if this is a feature change)?**
1. `fieldID` is no longer undefined for the fields.
2. Validation errors from validators do not cause unhandled js errors to be thrown in the console output.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
NO.

