### PR TITLE
V3 enable custom validators

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,15 @@ const install = (Vue, options = {}) => {
 			}
 		});
 	}
+
+	if (options.validators) {
+		for (let key in options.validators) {
+			if ({}.hasOwnProperty.call(options.validators, key)) {
+				validators[key] = options.validators[key];
+			}
+		}
+	}
+
 	Vue.component("VueFormGenerator", component);
 };
 

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -110,11 +110,11 @@ const validators = {
 
 		let err = [];
 		if (isString(value)) {
-			if (!isNil(field.fieldOptions.min) && value.length < field.fieldOptions.min) {
+			if (!isNil(field.fieldOptions) && !isNil(field.fieldOptions.min) && value.length < field.fieldOptions.min) {
 				err.push(msg(messages.textTooSmall, value.length, field.fieldOptions.min));
 			}
 
-			if (!isNil(field.fieldOptions.max) && value.length > field.fieldOptions.max) {
+			if (!isNil(field.fieldOptions) && !isNil(field.fieldOptions.max) && value.length > field.fieldOptions.max) {
 				err.push(msg(messages.textTooBig, value.length, field.fieldOptions.max));
 			}
 		} else {
@@ -136,11 +136,11 @@ const validators = {
 		}
 
 		if (!isNil(value)) {
-			if (!isNil(field.fieldOptions.min) && value.length < field.fieldOptions.min) {
+			if (!isNil(field.fieldOptions) && !isNil(field.fieldOptions.min) && value.length < field.fieldOptions.min) {
 				return [msg(messages.selectMinItems, field.fieldOptions.min)];
 			}
 
-			if (!isNil(field.fieldOptions.max) && value.length > field.fieldOptions.max) {
+			if (!isNil(field.fieldOptions) && !isNil(field.fieldOptions.max) && value.length > field.fieldOptions.max) {
 				return [msg(messages.selectMaxItems, field.fieldOptions.max)];
 			}
 		}
@@ -157,14 +157,14 @@ const validators = {
 
 		let err = [];
 
-		if (!isNil(field.fieldOptions.min)) {
+		if (!isNil(field.fieldOptions) && !isNil(field.fieldOptions.min)) {
 			let min = new Date(field.fieldOptions.min);
 			if (m.valueOf() < min.valueOf()) {
 				err.push(msg(messages.dateIsEarly, fecha.format(m), fecha.format(min)));
 			}
 		}
 
-		if (!isNil(field.fieldOptions.max)) {
+		if (!isNil(field.fieldOptions) && !isNil(field.fieldOptions.max)) {
 			let max = new Date(field.fieldOptions.max);
 			if (m.valueOf() > max.valueOf()) {
 				err.push(msg(messages.dateIsLate, fecha.format(m), fecha.format(max)));


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

1. Adds support for custom validators

2. Fixes bugs in validators where errors would occur if we tried to access attributes `min, max` in `field.fieldOptions` when it was undefined


- **What is the current behavior?** (You can also link to an open issue here)
1. You can't add custom validators in v3, which is already supported in v2.x.x.

2. Some Validators are throwing errors
    In some validator functions, we were checking the existence
    of min and max values in the field schema using
    !isNil(field.fieldOptions.min) and !isNil(field.fieldOptions.max).

    However, some fields might have very simple configuration which
    doesn't include fieldOptions object, meaning that this code
    will throw an error

    ```js
    TypeError: Cannot read property 'min' of undefined
    ```
    which vue throws as something like

    ```js
    vue.esm.js:629 [Vue warn]: Error in event handler for "validate-fields": "TypeError: Cannot read property 'min' of undefined"
    ```
    To guard against this, we need to first make sure that
    fieldOptions also exists before we try to check whether attributes in it
    are defined.

    This was already present in `number` validator, but was missing in
    `date`, `array` and `string`.


* **What is the new behavior (if this is a feature change)?**

1. No more errors for validators
2. You can define custom validators when creating the vfg instance, in the same way as it is done in v2.x.x.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
NO.

