### PR TITLE
v3 Add group visibility control

### DIFF
--- a/src/formGroup.vue
+++ b/src/formGroup.vue
@@ -1,5 +1,5 @@
 <template>
-	<fieldset v-if="fields"
+	<fieldset v-if="fields && groupVisible(group)"
 		:is="tag"
 		:class="[groupRowClasses, validationClass]"
 		ref="group">
@@ -147,6 +147,19 @@ export default {
 			}
 
 			return field.visible;
+		},
+
+		// Get visible prop of the group
+		groupVisible(group) {
+			if (isFunction(group.visible)) {
+				return group.visible.call(this, this.model, group, this);
+			}
+
+			if (isNil(group.visible)) {
+				return true;
+			}
+
+			return group.visible;
 		},
 
 		getGroupTag(field) {


### PR DESCRIPTION
I would like to be able to control the visibility of the group.
This has already been implemented in a pending PR in master
https://github.com/vue-generators/vue-form-generator/pull/606

Added it to v3.

* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

It introduces ability to show and hide entire groups.

- **What is the current behavior?** (You can also link to an open issue here)
Groups can't be toggled.

* **What is the new behavior (if this is a feature change)?**
Groups can be toggled in the same way fields are toggled. A `visible` attribute on the group schema is all that is needed.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
NO.
