### PR TITLE
Add better support for bootstrap horizontal form

### DIFF
--- a/src/formElement.vue
+++ b/src/formElement.vue
@@ -16,43 +16,45 @@
 				:getValueFromOption="getValueFromOption"></slot>
 		</label>
 
-		<div class="field-wrap">
-			<component
-				ref="child"
-				:is="fieldType"
-				:model="model"
-				:schema="field"
-				:form-options="options"
-				:event-bus="eventBus"
-				:field-id="fieldID"
-				@field-touched="onFieldTouched"
-				@errors-updated="onChildValidated"></component>
-			<div
-				v-if="buttonsAreVisible"
-				class="buttons">
-				<button
-					v-for="(btn, index) in field.buttons"
-					@click="buttonClickHandler(btn, field, $event)"
-					:class="btn.classes"
-					:key="index"
-					v-text="btn.label"></button>
+		<div class="field-content">
+			<div class="field-wrap">
+				<component
+					ref="child"
+					:is="fieldType"
+					:model="model"
+					:schema="field"
+					:form-options="options"
+					:event-bus="eventBus"
+					:field-id="fieldID"
+					@field-touched="onFieldTouched"
+					@errors-updated="onChildValidated"></component>
+				<div
+					v-if="buttonsAreVisible"
+					class="buttons">
+					<button
+						v-for="(btn, index) in field.buttons"
+						@click="buttonClickHandler(btn, field, $event)"
+						:class="btn.classes"
+						:key="index"
+						v-text="btn.label"></button>
+				</div>
 			</div>
+
+			<template v-if="fieldHasHint">
+				<slot
+					name="hint"
+					:field="field"
+					:getValueFromOption="getValueFromOption"></slot>
+			</template>
+
+			<template v-if="fieldHasErrors">
+				<slot
+					name="errors"
+					:childErrors="childErrors"
+					:field="field"
+					:getValueFromOption="getValueFromOption" ></slot>
+			</template>
 		</div>
-
-		<template v-if="fieldHasHint">
-			<slot
-				name="hint"
-				:field="field"
-				:getValueFromOption="getValueFromOption"></slot>
-		</template>
-
-		<template v-if="fieldHasErrors">
-			<slot
-				name="errors"
-				:childErrors="childErrors"
-				:field="field"
-				:getValueFromOption="getValueFromOption" ></slot>
-		</template>
 	</div>
 </template>
 <script>


### PR DESCRIPTION
I wrapped the form element, along with its hint and error
messages with a div.field-content.

This provides separation of the label of the element from the
actual input element, which is necessary in order to have a proper
horizontal form design.

In bootstrap v4 horizontal forms, we have the label on the left hand side,
and the input element (along with accompanying content like hints
below it and validation messages) floated to the right.

Without wrapping the field in a div, the content under the input
would not be properly aligned with the input itself if the input
is offset from the left-most border of it's parent. This means
that horizontal forms wouldn't work well.

I decided to add another div instead of moving the hint and error
messages into the div.field-wrap because I think there might still
be use-cases where you would want to have a separate parent for the
field-element.

The inserted div shouldn't affect styling, since in css it can be defined
as block, flex, inline, inline-block e.t.c to the users needs.

* **Please check if the PR fulfills these requirements**

- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- **What is the current behavior?** (You can also link to an open issue here)

* **What is the new behavior (if this is a feature change)?**

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
