### PR TITLE
Add subgroups + custom group tags

### DIFF
--- a/dev/projects/grouping/app.vue
+++ b/dev/projects/grouping/app.vue
@@ -25,6 +25,9 @@ export default {
 			model: {
 				name: "Brian Blessed",
 				email: "brian@hawkman.mongo",
+				city: "Springfield",
+				state: "IL",
+				age: 25,
 				others: {
 					more: "More",
 					things: "Things"
@@ -48,6 +51,41 @@ export default {
 								inputType: "email",
 								label: "Email",
 								model: "email"
+							}
+						]
+					},
+					{
+						groups: [
+							{
+								legend: "Location",
+								fields: [
+									{
+										type: "input",
+										inputType: "text",
+										label: "City",
+										model: "city",
+										styleClasses: "half-width"
+									},
+									{
+										type: "input",
+										inputType: "text",
+										label: "State",
+										model: "state",
+										styleClasses: "half-width"
+									}
+								]
+							},
+							{
+								legend: "Demographics",
+								fields: [
+									{
+										type: "input",
+										inputType: "number",
+										label: "Age",
+										model: "age",
+										styleClasses: "half-width"
+									}
+								]
 							}
 						]
 					},
@@ -90,6 +128,16 @@ export default {
 	}
 };
 </script>
+
+<style>
+/* To demonstrate subgroups */
+section section legend {
+	color: #777;
+	border: 0;
+	margin-bottom: 10px;
+	font-size: 18px;
+}
+</style>
 
 <style lang="scss">
 @import "../../style.scss";

--- a/dev/style.scss
+++ b/dev/style.scss
@@ -57,7 +57,7 @@ pre {
 	}
 }
 
-fieldset.vue-form-generator {
+.vue-form-generator {
 	.form-group.half-width {
 		width: 50%;
 	}

--- a/src/formGenerator.vue
+++ b/src/formGenerator.vue
@@ -5,10 +5,15 @@ div.vue-form-generator(v-if='schema != null')
 			form-group(v-if='fieldVisible(field)', :vfg="vfg", :field="field", :errors="errors", :model="model", :options="options", @validated="onFieldValidated", @model-updated="onModelUpdated")
 
 	template(v-for='group in groups')
-		fieldset(:is='tag', :class='getFieldRowClasses(group)')
+		fieldset(:is='group.tag || tag', :class='getFieldRowClasses(group)', v-bind="{ [group.legendAttr]: group.legend }")
 			legend(v-if='group.legend') {{ group.legend }}
 			template(v-for='field in group.fields')
 				form-group(v-if='fieldVisible(field)', :vfg="vfg", :field="field", :errors="errors", :model="model", :options="options", @validated="onFieldValidated", @model-updated="onModelUpdated")
+			template(v-for='subGroup in group.groups')
+				fieldset(:is='subGroup.tag || tag', :class='getFieldRowClasses(subGroup)', v-bind="{ [subGroup.legendAttr]: subGroup.legend }")
+					legend(v-if='subGroup.legend') {{ subGroup.legend }}
+					template(v-for='nestedField in subGroup.fields')
+						form-group(v-if='fieldVisible(nestedField)', :vfg="vfg", :field="nestedField", :errors="errors", :model="model", :options="options", @validated="onFieldValidated", @model-updated="onModelUpdated")
 </template>
 
 <script>
@@ -201,7 +206,9 @@ export default {
 			this.errors.splice(0);
 
 			forEach(this.$children, child => {
-				child.clearValidationErrors();
+				if (child.clearValidationErrors) {
+					child.clearValidationErrors();
+				}
 			});
 		},
 	}

--- a/test/unit/specs/VueFormGenerator.spec.js
+++ b/test/unit/specs/VueFormGenerator.spec.js
@@ -171,6 +171,88 @@ describe("VueFormGenerator.vue", () => {
 		});
 	});
 
+	describe("check subgroups", () => {
+		let schema = {
+			groups: [
+				{
+					legend: "Test Legend",
+					groups: [
+						{
+							legend: "Nested Legend",
+							legendAttr: "title",
+							fields: [
+								{
+									type: "input",
+									inputType: "text",
+									label: "Name",
+									model: "name",
+								}
+							]
+						}
+					]
+				},
+			]
+		};
+		let label;
+		let fieldset;
+
+		before(() => {
+			createFormGenerator({ schema });
+			label = wrapper.find("fieldset fieldset legend");
+			fieldset = wrapper.find("fieldset fieldset");
+		});
+
+		it("should render nested legend", () => {
+			expect(label.exists()).to.be.true;
+			expect(label.text()).to.be.equal("Nested Legend");
+		});
+
+		it("should render nested legend in specified attribute", () => {
+			expect(fieldset.attributes().title).to.be.equal("Nested Legend");
+		});
+	});
+
+	describe("check group tag definition", () => {
+		let schema = {
+			groups: [
+				{
+					tag: "section",
+					legend: "Test Legend",
+					groups: [
+						{
+							tag: "aside",
+							legend: "Nested Legend",
+							fields: [
+								{
+									type: "input",
+									inputType: "text",
+									label: "Name",
+									model: "name",
+								}
+							]
+						}
+					]
+				},
+			]
+		};
+
+		before(() => {
+			createFormGenerator({ schema });
+		});
+
+		it("should create custom tag", () => {
+			const section = wrapper.find("section");
+			expect(section.exists()).to.be.true;
+			expect(section.is("section")).to.be.true;
+		});
+
+		it("should create custom tag (nested)", () => {
+			const aside = wrapper.find("section aside");
+			expect(aside.exists()).to.be.true;
+			expect(aside.is("aside")).to.be.true;
+		});
+	});
+
 	describe("check label classes", () => {
 		let schema = {
 			fields: [


### PR DESCRIPTION
* **What kind of change does this PR introduce?** 
  - A feature to add a subgroup within a group
  - A feature to specify group tag per group

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No, feature addition only.

* **Other information**:
Please see https://github.com/vue-generators/vue-form-generator-docs/pull/28 for documentation

---

I've also added subgroups to the dev group example:

<img width="1131" alt="Screen Shot 2020-04-18 at 2 16 29 PM" src="https://user-images.githubusercontent.com/611996/79669412-e2daab80-8180-11ea-9a05-bb03fb80cec8.png">

---

Since these changes allow custom tags and subgroups, complex behavior like putting subgroups into tabs is possible. Here's what it looks like with bootstrap-vue tabs for subgroups:

<img width="1148" alt="Screen Shot 2020-04-18 at 2 17 12 PM" src="https://user-images.githubusercontent.com/611996/79669418-ef5f0400-8180-11ea-9ff0-4bf63c56673c.png">

---

Please let me know if there's anything you would like done differently! I hope we can get this subgrouping behavior in, we are using vfg in a project with very complex forms and could really use something like this. 

Related issue: #285 