### PR TITLE
fix(validation): URL validation for URL(s) with more than four characters TLD

### DIFF
--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -198,7 +198,7 @@ const validators = {
 		let res = checkEmpty(value, field.required, messages);
 		if (res != null) return res;
 
-		let re = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g; // eslint-disable-line no-useless-escape
+		let re = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g; // eslint-disable-line no-useless-escape
 		if (!re.test(value)) {
 			return [msg(messages.invalidURL)];
 		}

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -198,7 +198,7 @@ const validators = {
 		let res = checkEmpty(value, field.required, messages);
 		if (res != null) return res;
 
-		let re = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,5}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g; // eslint-disable-line no-useless-escape
+		let re = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g; // eslint-disable-line no-useless-escape
 		if (!re.test(value)) {
 			return [msg(messages.invalidURL)];
 		}

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -198,7 +198,7 @@ const validators = {
 		let res = checkEmpty(value, field.required, messages);
 		if (res != null) return res;
 
-		let re = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,4}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g; // eslint-disable-line no-useless-escape
+		let re = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,5}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g; // eslint-disable-line no-useless-escape
 		if (!re.test(value)) {
 			return [msg(messages.invalidURL)];
 		}


### PR DESCRIPTION
This __PR__ is mainly to fix URL validation for URL(s) with more than four characters TLD (e.g. `.store`, `.online`, `.studio`, `.design`, `.international` ...)

* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
It gives invalid URL message for URLs five-plus characters TLD (example this website [`https://mycatalog.store/`](https://mycatalog.store/))

* **What is the new behavior (if this is a feature change)?**
URLs with more than four characters TLD should tread as a valid URLs.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No breaking change

* **Other information**:
